### PR TITLE
chore(dependabot): set package-ecosystem gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 version: 2
 updates:
   # Dependabot for go
-  - package-ecosystem: go
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
       # If you'd like a different schedule feel free to increase the frequency
@@ -11,7 +11,7 @@ updates:
       # Dependabot runs sometime on Thursdays, so results are available on
       # Fridays, regardless of timezone. We _could_ run at a specific early
       # Friday time, but then everyone would run at the same time.
-      day: "thursday"
+      day: "monday"
   # Dependabot for docker
   - package-ecosystem: docker
     directory: "/"
@@ -22,7 +22,7 @@ updates:
       # Dependabot runs sometime on Thursdays, so results are available on
       # Fridays, regardless of timezone. We _could_ run at a specific early
       # Friday time, but then everyone would run at the same time.
-      day: "thursday"
+      day: "monday"
   # Dependabot for actions
   - package-ecosystem: github-actions
     directory: "/"
@@ -33,4 +33,4 @@ updates:
       # Dependabot runs sometime on Thursdays, so results are available on
       # Fridays, regardless of timezone. We _could_ run at a specific early
       # Friday time, but then everyone would run at the same time.
-      day: "thursday"
+      day: "monday"


### PR DESCRIPTION
Use correct package ecosystem value for go (gomod)

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem