### PR TITLE
feat(service): add mutations for relations

### DIFF
--- a/internal/api/graphql/graph/generated.go
+++ b/internal/api/graphql/graph/generated.go
@@ -348,45 +348,53 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateActivity          func(childComplexity int, input model.ActivityInput) int
-		CreateComponent         func(childComplexity int, input model.ComponentInput) int
-		CreateComponentInstance func(childComplexity int, input model.ComponentInstanceInput) int
-		CreateComponentVersion  func(childComplexity int, input model.ComponentVersionInput) int
-		CreateEvidence          func(childComplexity int, input model.EvidenceInput) int
-		CreateIssue             func(childComplexity int, input model.IssueInput) int
-		CreateIssueMatch        func(childComplexity int, input model.IssueMatchInput) int
-		CreateIssueMatchChange  func(childComplexity int, input model.IssueMatchChangeInput) int
-		CreateIssueRepository   func(childComplexity int, input model.IssueRepositoryInput) int
-		CreateIssueVariant      func(childComplexity int, input model.IssueVariantInput) int
-		CreateService           func(childComplexity int, input model.ServiceInput) int
-		CreateSupportGroup      func(childComplexity int, input model.SupportGroupInput) int
-		CreateUser              func(childComplexity int, input model.UserInput) int
-		DeleteActivity          func(childComplexity int, id string) int
-		DeleteComponent         func(childComplexity int, id string) int
-		DeleteComponentInstance func(childComplexity int, id string) int
-		DeleteComponentVersion  func(childComplexity int, id string) int
-		DeleteEvidence          func(childComplexity int, id string) int
-		DeleteIssue             func(childComplexity int, id string) int
-		DeleteIssueMatch        func(childComplexity int, id string) int
-		DeleteIssueMatchChange  func(childComplexity int, id string) int
-		DeleteIssueRepository   func(childComplexity int, id string) int
-		DeleteIssueVariant      func(childComplexity int, id string) int
-		DeleteService           func(childComplexity int, id string) int
-		DeleteSupportGroup      func(childComplexity int, id string) int
-		DeleteUser              func(childComplexity int, id string) int
-		UpdateActivity          func(childComplexity int, id string, input model.ActivityInput) int
-		UpdateComponent         func(childComplexity int, id string, input model.ComponentInput) int
-		UpdateComponentInstance func(childComplexity int, id string, input model.ComponentInstanceInput) int
-		UpdateComponentVersion  func(childComplexity int, id string, input model.ComponentVersionInput) int
-		UpdateEvidence          func(childComplexity int, id string, input model.EvidenceInput) int
-		UpdateIssue             func(childComplexity int, id string, input model.IssueInput) int
-		UpdateIssueMatch        func(childComplexity int, id string, input model.IssueMatchInput) int
-		UpdateIssueMatchChange  func(childComplexity int, id string, input model.IssueMatchChangeInput) int
-		UpdateIssueRepository   func(childComplexity int, id string, input model.IssueRepositoryInput) int
-		UpdateIssueVariant      func(childComplexity int, id string, input model.IssueVariantInput) int
-		UpdateService           func(childComplexity int, id string, input model.ServiceInput) int
-		UpdateSupportGroup      func(childComplexity int, id string, input model.SupportGroupInput) int
-		UpdateUser              func(childComplexity int, id string, input model.UserInput) int
+		AddIssueRepositoryToService      func(childComplexity int, serviceID string, issueRepositoryID string, priority int) int
+		AddOwnerToService                func(childComplexity int, serviceID string, userID string) int
+		AddServiceToActivity             func(childComplexity int, activityID string, serviceID string) int
+		AddServiceToSupportGroup         func(childComplexity int, supportGroupID string, serviceID string) int
+		CreateActivity                   func(childComplexity int, input model.ActivityInput) int
+		CreateComponent                  func(childComplexity int, input model.ComponentInput) int
+		CreateComponentInstance          func(childComplexity int, input model.ComponentInstanceInput) int
+		CreateComponentVersion           func(childComplexity int, input model.ComponentVersionInput) int
+		CreateEvidence                   func(childComplexity int, input model.EvidenceInput) int
+		CreateIssue                      func(childComplexity int, input model.IssueInput) int
+		CreateIssueMatch                 func(childComplexity int, input model.IssueMatchInput) int
+		CreateIssueMatchChange           func(childComplexity int, input model.IssueMatchChangeInput) int
+		CreateIssueRepository            func(childComplexity int, input model.IssueRepositoryInput) int
+		CreateIssueVariant               func(childComplexity int, input model.IssueVariantInput) int
+		CreateService                    func(childComplexity int, input model.ServiceInput) int
+		CreateSupportGroup               func(childComplexity int, input model.SupportGroupInput) int
+		CreateUser                       func(childComplexity int, input model.UserInput) int
+		DeleteActivity                   func(childComplexity int, id string) int
+		DeleteComponent                  func(childComplexity int, id string) int
+		DeleteComponentInstance          func(childComplexity int, id string) int
+		DeleteComponentVersion           func(childComplexity int, id string) int
+		DeleteEvidence                   func(childComplexity int, id string) int
+		DeleteIssue                      func(childComplexity int, id string) int
+		DeleteIssueMatch                 func(childComplexity int, id string) int
+		DeleteIssueMatchChange           func(childComplexity int, id string) int
+		DeleteIssueRepository            func(childComplexity int, id string) int
+		DeleteIssueVariant               func(childComplexity int, id string) int
+		DeleteService                    func(childComplexity int, id string) int
+		DeleteSupportGroup               func(childComplexity int, id string) int
+		DeleteUser                       func(childComplexity int, id string) int
+		RemoveIssueRepositoryFromService func(childComplexity int, serviceID string, issueRepositoryID string) int
+		RemoveOwnerFromService           func(childComplexity int, serviceID string, userID string) int
+		RemoveServiceFromActivity        func(childComplexity int, activityID string, serviceID string) int
+		RemoveServiceFromSupportGroup    func(childComplexity int, supportGroupID string, serviceID string) int
+		UpdateActivity                   func(childComplexity int, id string, input model.ActivityInput) int
+		UpdateComponent                  func(childComplexity int, id string, input model.ComponentInput) int
+		UpdateComponentInstance          func(childComplexity int, id string, input model.ComponentInstanceInput) int
+		UpdateComponentVersion           func(childComplexity int, id string, input model.ComponentVersionInput) int
+		UpdateEvidence                   func(childComplexity int, id string, input model.EvidenceInput) int
+		UpdateIssue                      func(childComplexity int, id string, input model.IssueInput) int
+		UpdateIssueMatch                 func(childComplexity int, id string, input model.IssueMatchInput) int
+		UpdateIssueMatchChange           func(childComplexity int, id string, input model.IssueMatchChangeInput) int
+		UpdateIssueRepository            func(childComplexity int, id string, input model.IssueRepositoryInput) int
+		UpdateIssueVariant               func(childComplexity int, id string, input model.IssueVariantInput) int
+		UpdateService                    func(childComplexity int, id string, input model.ServiceInput) int
+		UpdateSupportGroup               func(childComplexity int, id string, input model.SupportGroupInput) int
+		UpdateUser                       func(childComplexity int, id string, input model.UserInput) int
 	}
 
 	Page struct {
@@ -549,6 +557,8 @@ type MutationResolver interface {
 	CreateSupportGroup(ctx context.Context, input model.SupportGroupInput) (*model.SupportGroup, error)
 	UpdateSupportGroup(ctx context.Context, id string, input model.SupportGroupInput) (*model.SupportGroup, error)
 	DeleteSupportGroup(ctx context.Context, id string) (string, error)
+	AddServiceToSupportGroup(ctx context.Context, supportGroupID string, serviceID string) (*model.SupportGroup, error)
+	RemoveServiceFromSupportGroup(ctx context.Context, supportGroupID string, serviceID string) (*model.SupportGroup, error)
 	CreateComponent(ctx context.Context, input model.ComponentInput) (*model.Component, error)
 	UpdateComponent(ctx context.Context, id string, input model.ComponentInput) (*model.Component, error)
 	DeleteComponent(ctx context.Context, id string) (string, error)
@@ -561,6 +571,10 @@ type MutationResolver interface {
 	CreateService(ctx context.Context, input model.ServiceInput) (*model.Service, error)
 	UpdateService(ctx context.Context, id string, input model.ServiceInput) (*model.Service, error)
 	DeleteService(ctx context.Context, id string) (string, error)
+	AddOwnerToService(ctx context.Context, serviceID string, userID string) (*model.Service, error)
+	RemoveOwnerFromService(ctx context.Context, serviceID string, userID string) (*model.Service, error)
+	AddIssueRepositoryToService(ctx context.Context, serviceID string, issueRepositoryID string, priority int) (*model.Service, error)
+	RemoveIssueRepositoryFromService(ctx context.Context, serviceID string, issueRepositoryID string) (*model.Service, error)
 	CreateIssueRepository(ctx context.Context, input model.IssueRepositoryInput) (*model.IssueRepository, error)
 	UpdateIssueRepository(ctx context.Context, id string, input model.IssueRepositoryInput) (*model.IssueRepository, error)
 	DeleteIssueRepository(ctx context.Context, id string) (string, error)
@@ -582,6 +596,8 @@ type MutationResolver interface {
 	CreateActivity(ctx context.Context, input model.ActivityInput) (*model.Activity, error)
 	UpdateActivity(ctx context.Context, id string, input model.ActivityInput) (*model.Activity, error)
 	DeleteActivity(ctx context.Context, id string) (string, error)
+	AddServiceToActivity(ctx context.Context, activityID string, serviceID string) (*model.Activity, error)
+	RemoveServiceFromActivity(ctx context.Context, activityID string, serviceID string) (*model.Activity, error)
 }
 type QueryResolver interface {
 	Issues(ctx context.Context, filter *model.IssueFilter, first *int, after *string) (*model.IssueConnection, error)
@@ -1950,6 +1966,54 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.IssueVariantEdge.UpdatedAt(childComplexity), true
 
+	case "Mutation.addIssueRepositoryToService":
+		if e.complexity.Mutation.AddIssueRepositoryToService == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addIssueRepositoryToService_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddIssueRepositoryToService(childComplexity, args["serviceId"].(string), args["issueRepositoryId"].(string), args["priority"].(int)), true
+
+	case "Mutation.addOwnerToService":
+		if e.complexity.Mutation.AddOwnerToService == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addOwnerToService_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddOwnerToService(childComplexity, args["serviceId"].(string), args["userId"].(string)), true
+
+	case "Mutation.addServiceToActivity":
+		if e.complexity.Mutation.AddServiceToActivity == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addServiceToActivity_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddServiceToActivity(childComplexity, args["activityId"].(string), args["serviceId"].(string)), true
+
+	case "Mutation.addServiceToSupportGroup":
+		if e.complexity.Mutation.AddServiceToSupportGroup == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addServiceToSupportGroup_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddServiceToSupportGroup(childComplexity, args["supportGroupId"].(string), args["serviceId"].(string)), true
+
 	case "Mutation.createActivity":
 		if e.complexity.Mutation.CreateActivity == nil {
 			break
@@ -2261,6 +2325,54 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteUser(childComplexity, args["id"].(string)), true
+
+	case "Mutation.removeIssueRepositoryFromService":
+		if e.complexity.Mutation.RemoveIssueRepositoryFromService == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeIssueRepositoryFromService_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveIssueRepositoryFromService(childComplexity, args["serviceId"].(string), args["issueRepositoryId"].(string)), true
+
+	case "Mutation.removeOwnerFromService":
+		if e.complexity.Mutation.RemoveOwnerFromService == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeOwnerFromService_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveOwnerFromService(childComplexity, args["serviceId"].(string), args["userId"].(string)), true
+
+	case "Mutation.removeServiceFromActivity":
+		if e.complexity.Mutation.RemoveServiceFromActivity == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeServiceFromActivity_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveServiceFromActivity(childComplexity, args["activityId"].(string), args["serviceId"].(string)), true
+
+	case "Mutation.removeServiceFromSupportGroup":
+		if e.complexity.Mutation.RemoveServiceFromSupportGroup == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_removeServiceFromSupportGroup_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RemoveServiceFromSupportGroup(childComplexity, args["supportGroupId"].(string), args["serviceId"].(string)), true
 
 	case "Mutation.updateActivity":
 		if e.complexity.Mutation.UpdateActivity == nil {
@@ -3653,6 +3765,111 @@ func (ec *executionContext) field_Issue_issueVariants_args(ctx context.Context, 
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_addIssueRepositoryToService_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["issueRepositoryId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issueRepositoryId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issueRepositoryId"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["priority"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("priority"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["priority"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_addOwnerToService_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["userId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["userId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_addServiceToActivity_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["activityId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("activityId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["activityId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_addServiceToSupportGroup_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["supportGroupId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("supportGroupId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["supportGroupId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_createActivity_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -4040,6 +4257,102 @@ func (ec *executionContext) field_Mutation_deleteUser_args(ctx context.Context, 
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_removeIssueRepositoryFromService_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["issueRepositoryId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issueRepositoryId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issueRepositoryId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_removeOwnerFromService_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["userId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["userId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_removeServiceFromActivity_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["activityId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("activityId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["activityId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_removeServiceFromSupportGroup_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["supportGroupId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("supportGroupId"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["supportGroupId"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["serviceId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceId"))
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["serviceId"] = arg1
 	return args, nil
 }
 
@@ -13867,6 +14180,136 @@ func (ec *executionContext) fieldContext_Mutation_deleteSupportGroup(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_addServiceToSupportGroup(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_addServiceToSupportGroup(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddServiceToSupportGroup(rctx, fc.Args["supportGroupId"].(string), fc.Args["serviceId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SupportGroup)
+	fc.Result = res
+	return ec.marshalNSupportGroup2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐSupportGroup(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addServiceToSupportGroup(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SupportGroup_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SupportGroup_name(ctx, field)
+			case "users":
+				return ec.fieldContext_SupportGroup_users(ctx, field)
+			case "services":
+				return ec.fieldContext_SupportGroup_services(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SupportGroup", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addServiceToSupportGroup_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeServiceFromSupportGroup(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeServiceFromSupportGroup(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveServiceFromSupportGroup(rctx, fc.Args["supportGroupId"].(string), fc.Args["serviceId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SupportGroup)
+	fc.Result = res
+	return ec.marshalNSupportGroup2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐSupportGroup(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeServiceFromSupportGroup(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SupportGroup_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SupportGroup_name(ctx, field)
+			case "users":
+				return ec.fieldContext_SupportGroup_users(ctx, field)
+			case "services":
+				return ec.fieldContext_SupportGroup_services(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SupportGroup", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeServiceFromSupportGroup_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createComponent(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_createComponent(ctx, field)
 	if err != nil {
@@ -14641,6 +15084,290 @@ func (ec *executionContext) fieldContext_Mutation_deleteService(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_addOwnerToService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_addOwnerToService(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddOwnerToService(rctx, fc.Args["serviceId"].(string), fc.Args["userId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Service)
+	fc.Result = res
+	return ec.marshalNService2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐService(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addOwnerToService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Service_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Service_name(ctx, field)
+			case "owners":
+				return ec.fieldContext_Service_owners(ctx, field)
+			case "supportGroups":
+				return ec.fieldContext_Service_supportGroups(ctx, field)
+			case "activities":
+				return ec.fieldContext_Service_activities(ctx, field)
+			case "issueRepositories":
+				return ec.fieldContext_Service_issueRepositories(ctx, field)
+			case "componentInstances":
+				return ec.fieldContext_Service_componentInstances(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addOwnerToService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeOwnerFromService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeOwnerFromService(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveOwnerFromService(rctx, fc.Args["serviceId"].(string), fc.Args["userId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Service)
+	fc.Result = res
+	return ec.marshalNService2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐService(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeOwnerFromService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Service_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Service_name(ctx, field)
+			case "owners":
+				return ec.fieldContext_Service_owners(ctx, field)
+			case "supportGroups":
+				return ec.fieldContext_Service_supportGroups(ctx, field)
+			case "activities":
+				return ec.fieldContext_Service_activities(ctx, field)
+			case "issueRepositories":
+				return ec.fieldContext_Service_issueRepositories(ctx, field)
+			case "componentInstances":
+				return ec.fieldContext_Service_componentInstances(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeOwnerFromService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_addIssueRepositoryToService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_addIssueRepositoryToService(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddIssueRepositoryToService(rctx, fc.Args["serviceId"].(string), fc.Args["issueRepositoryId"].(string), fc.Args["priority"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Service)
+	fc.Result = res
+	return ec.marshalNService2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐService(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addIssueRepositoryToService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Service_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Service_name(ctx, field)
+			case "owners":
+				return ec.fieldContext_Service_owners(ctx, field)
+			case "supportGroups":
+				return ec.fieldContext_Service_supportGroups(ctx, field)
+			case "activities":
+				return ec.fieldContext_Service_activities(ctx, field)
+			case "issueRepositories":
+				return ec.fieldContext_Service_issueRepositories(ctx, field)
+			case "componentInstances":
+				return ec.fieldContext_Service_componentInstances(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addIssueRepositoryToService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeIssueRepositoryFromService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeIssueRepositoryFromService(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveIssueRepositoryFromService(rctx, fc.Args["serviceId"].(string), fc.Args["issueRepositoryId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Service)
+	fc.Result = res
+	return ec.marshalNService2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐService(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeIssueRepositoryFromService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Service_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Service_name(ctx, field)
+			case "owners":
+				return ec.fieldContext_Service_owners(ctx, field)
+			case "supportGroups":
+				return ec.fieldContext_Service_supportGroups(ctx, field)
+			case "activities":
+				return ec.fieldContext_Service_activities(ctx, field)
+			case "issueRepositories":
+				return ec.fieldContext_Service_issueRepositories(ctx, field)
+			case "componentInstances":
+				return ec.fieldContext_Service_componentInstances(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeIssueRepositoryFromService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -16080,6 +16807,144 @@ func (ec *executionContext) fieldContext_Mutation_deleteActivity(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteActivity_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_addServiceToActivity(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_addServiceToActivity(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AddServiceToActivity(rctx, fc.Args["activityId"].(string), fc.Args["serviceId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Activity)
+	fc.Result = res
+	return ec.marshalNActivity2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐActivity(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addServiceToActivity(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Activity_id(ctx, field)
+			case "status":
+				return ec.fieldContext_Activity_status(ctx, field)
+			case "services":
+				return ec.fieldContext_Activity_services(ctx, field)
+			case "issues":
+				return ec.fieldContext_Activity_issues(ctx, field)
+			case "evidences":
+				return ec.fieldContext_Activity_evidences(ctx, field)
+			case "issueMatchChanges":
+				return ec.fieldContext_Activity_issueMatchChanges(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Activity", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addServiceToActivity_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_removeServiceFromActivity(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_removeServiceFromActivity(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveServiceFromActivity(rctx, fc.Args["activityId"].(string), fc.Args["serviceId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Activity)
+	fc.Result = res
+	return ec.marshalNActivity2ᚖgithubᚗwdfᚗsapᚗcorpᚋccᚋheurekaᚋinternalᚋapiᚋgraphqlᚋgraphᚋmodelᚐActivity(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_removeServiceFromActivity(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Activity_id(ctx, field)
+			case "status":
+				return ec.fieldContext_Activity_status(ctx, field)
+			case "services":
+				return ec.fieldContext_Activity_services(ctx, field)
+			case "issues":
+				return ec.fieldContext_Activity_issues(ctx, field)
+			case "evidences":
+				return ec.fieldContext_Activity_evidences(ctx, field)
+			case "issueMatchChanges":
+				return ec.fieldContext_Activity_issueMatchChanges(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Activity", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_removeServiceFromActivity_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -24957,6 +25822,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "addServiceToSupportGroup":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addServiceToSupportGroup(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "removeServiceFromSupportGroup":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeServiceFromSupportGroup(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createComponent":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createComponent(ctx, field)
@@ -25037,6 +25916,34 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteService":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteService(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "addOwnerToService":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addOwnerToService(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "removeOwnerFromService":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeOwnerFromService(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "addIssueRepositoryToService":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addIssueRepositoryToService(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "removeIssueRepositoryFromService":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeIssueRepositoryFromService(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -25184,6 +26091,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteActivity":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteActivity(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "addServiceToActivity":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addServiceToActivity(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "removeServiceFromActivity":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_removeServiceFromActivity(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/internal/api/graphql/graph/queryCollection/activity/addService.graphql
+++ b/internal/api/graphql/graph/queryCollection/activity/addService.graphql
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($activityId: ID!, $serviceId: ID!) {
+    addServiceToActivity (
+        activityId: $activityId,
+        serviceId: $serviceId
+    ) {
+        id
+        services {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/activity/removeService.graphql
+++ b/internal/api/graphql/graph/queryCollection/activity/removeService.graphql
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($activityId: ID!, $serviceId: ID!) {
+    removeServiceFromActivity (
+        serviceId: $serviceId,
+        activityId: $activityId
+    ) {
+        id
+        services {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/service/addIssueRepository.graphql
+++ b/internal/api/graphql/graph/queryCollection/service/addIssueRepository.graphql
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($serviceId: ID!, $issueRepositoryId: ID!, $priority: Int!) {
+    addIssueRepositoryToService (
+        serviceId: $serviceId,
+        issueRepositoryId: $issueRepositoryId,
+        priority: $priority
+    ) {
+        id
+        name
+        issueRepositories {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/service/addOwner.graphql
+++ b/internal/api/graphql/graph/queryCollection/service/addOwner.graphql
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($serviceId: ID!, $userId: ID!) {
+    addOwnerToService (
+        serviceId: $serviceId,
+        userId: $userId
+    ) {
+        id
+        name
+        owners {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/service/removeIssueRepository.graphql
+++ b/internal/api/graphql/graph/queryCollection/service/removeIssueRepository.graphql
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($serviceId: ID!, $issueRepositoryId: ID!) {
+    removeIssueRepositoryFromService (
+        serviceId: $serviceId,
+        issueRepositoryId: $issueRepositoryId
+    ) {
+        id
+        name
+        issueRepositories {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/service/removeOwner.graphql
+++ b/internal/api/graphql/graph/queryCollection/service/removeOwner.graphql
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($serviceId: ID!, $userId: ID!) {
+    removeOwnerFromService (
+        serviceId: $serviceId,
+        userId: $userId
+    ) {
+        id
+        name
+        owners{
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/supportGroup/addService.graphql
+++ b/internal/api/graphql/graph/queryCollection/supportGroup/addService.graphql
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($supportGroupId: ID!, $serviceId: ID!) {
+    addServiceToSupportGroup (
+        supportGroupId: $supportGroupId,
+        serviceId: $serviceId
+    ) {
+        id
+        name
+        services {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/queryCollection/supportGroup/removeService.graphql
+++ b/internal/api/graphql/graph/queryCollection/supportGroup/removeService.graphql
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+mutation ($supportGroupId: ID!, $serviceId: ID!) {
+    removeServiceFromSupportGroup (
+        serviceId: $serviceId,
+        supportGroupId: $supportGroupId
+    ) {
+        id
+        name
+        services {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}

--- a/internal/api/graphql/graph/resolver/mutation.go
+++ b/internal/api/graphql/graph/resolver/mutation.go
@@ -95,6 +95,50 @@ func (r *mutationResolver) DeleteSupportGroup(ctx context.Context, id string) (s
 	return id, nil
 }
 
+// AddServiceToSupportGroup is the resolver for the addServiceToSupportGroup field.
+func (r *mutationResolver) AddServiceToSupportGroup(ctx context.Context, supportGroupID string, serviceID string) (*model.SupportGroup, error) {
+	supportGroupIdInt, err := baseResolver.ParseCursor(&supportGroupID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToSupportGroupMutationResolver", "Internal Error - when adding service to supportGroup")
+	}
+
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToSupportGroupMutationResolver", "Internal Error - when adding service to supportGroup")
+	}
+
+	supportGroup, err := r.App.AddServiceToSupportGroup(*supportGroupIdInt, *serviceIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToSupportGroupMutationResolver", "Internal Error - when adding service to supportGroup")
+	}
+
+	sg := model.NewSupportGroup(supportGroup)
+	return &sg, nil
+}
+
+// RemoveServiceFromSupportGroup is the resolver for the removeServiceFromSupportGroup field.
+func (r *mutationResolver) RemoveServiceFromSupportGroup(ctx context.Context, supportGroupID string, serviceID string) (*model.SupportGroup, error) {
+	supportGroupIdInt, err := baseResolver.ParseCursor(&supportGroupID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromSupportGroupMutationResolver", "Internal Error - when removing service from supportGroup")
+	}
+
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromSupportGroupMutationResolver", "Internal Error - when removing service from supportGroup")
+	}
+
+	supportGroup, err := r.App.RemoveServiceFromSupportGroup(*supportGroupIdInt, *serviceIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromSupportGroupMutationResolver", "Internal Error - when removing service from supportGroup")
+	}
+
+	sg := model.NewSupportGroup(supportGroup)
+	return &sg, nil
+}
+
 // CreateComponent is the resolver for the createComponent field.
 func (r *mutationResolver) CreateComponent(ctx context.Context, input model.ComponentInput) (*model.Component, error) {
 	component := model.NewComponentEntity(&input)
@@ -253,6 +297,94 @@ func (r *mutationResolver) DeleteService(ctx context.Context, id string) (string
 		return "", baseResolver.NewResolverError("DeleteServiceMutationResolver", "Internal Error - when deleting service")
 	}
 	return id, nil
+}
+
+// AddOwnerToService is the resolver for the addOwnerToService field.
+func (r *mutationResolver) AddOwnerToService(ctx context.Context, serviceID string, userID string) (*model.Service, error) {
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddOwnerToServiceMutationResolver", "Internal Error - when adding owner to service")
+	}
+
+	userIdInt, err := baseResolver.ParseCursor(&userID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddOwnerToServiceMutationResolver", "Internal Error - when adding owner to service")
+	}
+
+	service, err := r.App.AddOwnerToService(*serviceIdInt, *userIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddOwnerToServiceMutationResolver", "Internal Error - when adding owner to service")
+	}
+
+	s := model.NewService(service)
+	return &s, nil
+}
+
+// RemoveOwnerFromService is the resolver for the removeOwnerFromService field.
+func (r *mutationResolver) RemoveOwnerFromService(ctx context.Context, serviceID string, userID string) (*model.Service, error) {
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveOwnerFromServiceMutationResolver", "Internal Error - when removing owner from service")
+	}
+
+	userIdInt, err := baseResolver.ParseCursor(&userID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveOwnerFromServiceMutationResolver", "Internal Error - when removing owner from service")
+	}
+
+	service, err := r.App.RemoveOwnerFromService(*serviceIdInt, *userIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveOwnerFromServiceMutationResolver", "Internal Error - when removing owner from service")
+	}
+
+	s := model.NewService(service)
+	return &s, nil
+}
+
+// AddIssueRepositoryToService is the resolver for the addIssueRepositoryToService field.
+func (r *mutationResolver) AddIssueRepositoryToService(ctx context.Context, serviceID string, issueRepositoryID string, priority int) (*model.Service, error) {
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddIssueRepositoryToServiceMutationResolver", "Internal Error - when adding IssueRepository to service")
+	}
+
+	issueRepositoryIdInt, err := baseResolver.ParseCursor(&issueRepositoryID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddIssueRepositoryToServiceMutationResolver", "Internal Error - when adding IssueRepository to service")
+	}
+
+	service, err := r.App.AddIssueRepositoryToService(*serviceIdInt, *issueRepositoryIdInt, int64(priority))
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddIssueRepositoryToServiceMutationResolver", "Internal Error - when adding IssueRepository to service")
+	}
+
+	s := model.NewService(service)
+	return &s, nil
+}
+
+// RemoveIssueRepositoryFromService is the resolver for the removeIssueRepositoryFromService field.
+func (r *mutationResolver) RemoveIssueRepositoryFromService(ctx context.Context, serviceID string, issueRepositoryID string) (*model.Service, error) {
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveIssueRepositoryFromServiceMutationResolver", "Internal Error - when removing IssueRepository from service")
+	}
+
+	issueRepositoryIdInt, err := baseResolver.ParseCursor(&issueRepositoryID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveIssueRepositoryFromServiceMutationResolver", "Internal Error - when removing IssueRepository from service")
+	}
+
+	service, err := r.App.RemoveIssueRepositoryFromService(*serviceIdInt, *issueRepositoryIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveIssueRepositoryFromServiceMutationResolver", "Internal Error - when removing IssueRepository from service")
+	}
+
+	s := model.NewService(service)
+	return &s, nil
 }
 
 // CreateIssueRepository is the resolver for the createIssueRepository field.
@@ -533,6 +665,50 @@ func (r *mutationResolver) DeleteActivity(ctx context.Context, id string) (strin
 		return "", baseResolver.NewResolverError("DeleteActivityMutationResolver", "Internal Error - when deleting activity")
 	}
 	return id, nil
+}
+
+// AddServiceToActivity is the resolver for the addServiceToActivity field.
+func (r *mutationResolver) AddServiceToActivity(ctx context.Context, activityID string, serviceID string) (*model.Activity, error) {
+	activityIdInt, err := baseResolver.ParseCursor(&activityID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToActivityMutationResolver", "Internal Error - when adding service to activity")
+	}
+
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToActivityMutationResolver", "Internal Error - when adding service to activity")
+	}
+
+	activity, err := r.App.AddServiceToActivity(*activityIdInt, *serviceIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("AddServiceToActivityMutationResolver", "Internal Error - when adding service to activity")
+	}
+
+	a := model.NewActivity(activity)
+	return &a, nil
+}
+
+// RemoveServiceFromActivity is the resolver for the removeServiceFromActivity field.
+func (r *mutationResolver) RemoveServiceFromActivity(ctx context.Context, activityID string, serviceID string) (*model.Activity, error) {
+	activityIdInt, err := baseResolver.ParseCursor(&activityID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromActivityMutationResolver", "Internal Error - when removing service from activity")
+	}
+
+	serviceIdInt, err := baseResolver.ParseCursor(&serviceID)
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromActivityMutationResolver", "Internal Error - when removing service from activity")
+	}
+
+	activity, err := r.App.RemoveServiceFromActivity(*activityIdInt, *serviceIdInt)
+
+	if err != nil {
+		return nil, baseResolver.NewResolverError("RemoveServiceFromActivityMutationResolver", "Internal Error - when removing service from activity")
+	}
+
+	a := model.NewActivity(activity)
+	return &a, nil
 }
 
 // Mutation returns graph.MutationResolver implementation.

--- a/internal/api/graphql/graph/schema/mutation.graphqls
+++ b/internal/api/graphql/graph/schema/mutation.graphqls
@@ -9,6 +9,8 @@ type Mutation {
     createSupportGroup(input: SupportGroupInput!): SupportGroup!
     updateSupportGroup(id: ID!, input: SupportGroupInput!): SupportGroup!
     deleteSupportGroup(id: ID!): String!
+    addServiceToSupportGroup(supportGroupId: ID!, serviceId: ID!): SupportGroup!
+    removeServiceFromSupportGroup(supportGroupId: ID!, serviceId: ID!): SupportGroup!
 
     createComponent(input: ComponentInput!): Component!
     updateComponent(id: ID!, input: ComponentInput!): Component!
@@ -25,6 +27,10 @@ type Mutation {
     createService(input: ServiceInput!): Service!
     updateService(id: ID!, input: ServiceInput!): Service!
     deleteService(id: ID!): String!
+    addOwnerToService(serviceId: ID!, userId: ID!): Service!
+    removeOwnerFromService(serviceId: ID!, userId: ID!): Service!
+    addIssueRepositoryToService(serviceId: ID!, issueRepositoryId: ID!, priority: Int!): Service!
+    removeIssueRepositoryFromService(serviceId: ID!, issueRepositoryId: ID!): Service!
 
     createIssueRepository(input: IssueRepositoryInput!): IssueRepository!
     updateIssueRepository(id: ID!, input: IssueRepositoryInput!): IssueRepository!
@@ -53,4 +59,6 @@ type Mutation {
     createActivity(input: ActivityInput!): Activity!
     updateActivity(id: ID!, input: ActivityInput!): Activity!
     deleteActivity(id: ID!): String!
+    addServiceToActivity(activityId: ID!, serviceId: ID!): Activity!
+    removeServiceFromActivity(activityId: ID!, serviceId: ID!): Activity!
 }

--- a/internal/app/activity_test.go
+++ b/internal/app/activity_test.go
@@ -192,7 +192,7 @@ var _ = Describe("When deleting Activity", Label("app", "DeleteActivity"), func(
 	})
 })
 
-var _ = Describe("When modifying Service and Activity", Label("app", "ServiceActivity"), func() {
+var _ = Describe("When modifying relationship of Service and Activity", Label("app", "ServiceActivityRelationship"), func() {
 	var (
 		db       *mocks.MockDatabase
 		heureka  app.Heureka

--- a/internal/app/activity_test.go
+++ b/internal/app/activity_test.go
@@ -191,3 +191,47 @@ var _ = Describe("When deleting Activity", Label("app", "DeleteActivity"), func(
 		Expect(activities.Elements).To(BeEmpty(), "no error should be thrown")
 	})
 })
+
+var _ = Describe("When modifying Service and Activity", Label("app", "ServiceActivity"), func() {
+	var (
+		db       *mocks.MockDatabase
+		heureka  app.Heureka
+		service  entity.Service
+		activity entity.Activity
+		filter   *entity.ActivityFilter
+	)
+
+	BeforeEach(func() {
+		db = mocks.NewMockDatabase(GinkgoT())
+		service = test.NewFakeServiceEntity()
+		activity = test.NewFakeActivityEntity()
+		first := 10
+		var after int64
+		after = 0
+		filter = &entity.ActivityFilter{
+			Paginated: entity.Paginated{
+				First: &first,
+				After: &after,
+			},
+			Id: []*int64{&activity.Id},
+		}
+	})
+
+	It("adds service to activity", func() {
+		db.On("AddServiceToActivity", activity.Id, service.Id).Return(nil)
+		db.On("GetActivities", filter).Return([]entity.Activity{activity}, nil)
+		heureka = app.NewHeurekaApp(db)
+		activity, err := heureka.AddServiceToActivity(activity.Id, service.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(activity).NotTo(BeNil(), "activity should be returned")
+	})
+
+	It("removes service from activity", func() {
+		db.On("RemoveServiceFromActivity", activity.Id, service.Id).Return(nil)
+		db.On("GetActivities", filter).Return([]entity.Activity{activity}, nil)
+		heureka = app.NewHeurekaApp(db)
+		activity, err := heureka.RemoveServiceFromActivity(activity.Id, service.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(activity).NotTo(BeNil(), "activity should be returned")
+	})
+})

--- a/internal/app/interface.go
+++ b/internal/app/interface.go
@@ -37,6 +37,10 @@ type Heureka interface {
 	CreateService(*entity.Service) (*entity.Service, error)
 	UpdateService(*entity.Service) (*entity.Service, error)
 	DeleteService(int64) error
+	AddOwnerToService(int64, int64) (*entity.Service, error)
+	RemoveOwnerFromService(int64, int64) (*entity.Service, error)
+	AddIssueRepositoryToService(int64, int64, int64) (*entity.Service, error)
+	RemoveIssueRepositoryFromService(int64, int64) (*entity.Service, error)
 
 	ListUsers(*entity.UserFilter, *entity.ListOptions) (*entity.List[entity.UserResult], error)
 	CreateUser(*entity.User) (*entity.User, error)
@@ -47,6 +51,8 @@ type Heureka interface {
 	CreateSupportGroup(*entity.SupportGroup) (*entity.SupportGroup, error)
 	UpdateSupportGroup(*entity.SupportGroup) (*entity.SupportGroup, error)
 	DeleteSupportGroup(int64) error
+	AddServiceToSupportGroup(int64, int64) (*entity.SupportGroup, error)
+	RemoveServiceFromSupportGroup(int64, int64) (*entity.SupportGroup, error)
 
 	ListComponentInstances(*entity.ComponentInstanceFilter, *entity.ListOptions) (*entity.List[entity.ComponentInstanceResult], error)
 	CreateComponentInstance(*entity.ComponentInstance) (*entity.ComponentInstance, error)
@@ -57,6 +63,8 @@ type Heureka interface {
 	CreateActivity(*entity.Activity) (*entity.Activity, error)
 	UpdateActivity(*entity.Activity) (*entity.Activity, error)
 	DeleteActivity(int64) error
+	AddServiceToActivity(int64, int64) (*entity.Activity, error)
+	RemoveServiceFromActivity(int64, int64) (*entity.Activity, error)
 
 	ListEvidences(*entity.EvidenceFilter, *entity.ListOptions) (*entity.List[entity.EvidenceResult], error)
 	CreateEvidence(*entity.Evidence) (*entity.Evidence, error)

--- a/internal/app/interface.go
+++ b/internal/app/interface.go
@@ -34,6 +34,7 @@ type Heureka interface {
 	DeleteIssueMatchChange(int64) error
 
 	ListServices(*entity.ServiceFilter, *entity.ListOptions) (*entity.List[entity.ServiceResult], error)
+	GetService(int64) (*entity.Service, error)
 	CreateService(*entity.Service) (*entity.Service, error)
 	UpdateService(*entity.Service) (*entity.Service, error)
 	DeleteService(int64) error
@@ -48,6 +49,7 @@ type Heureka interface {
 	DeleteUser(int64) error
 
 	ListSupportGroups(*entity.SupportGroupFilter, *entity.ListOptions) (*entity.List[entity.SupportGroupResult], error)
+	GetSupportGroup(int64) (*entity.SupportGroup, error)
 	CreateSupportGroup(*entity.SupportGroup) (*entity.SupportGroup, error)
 	UpdateSupportGroup(*entity.SupportGroup) (*entity.SupportGroup, error)
 	DeleteSupportGroup(int64) error
@@ -60,6 +62,7 @@ type Heureka interface {
 	DeleteComponentInstance(int64) error
 
 	ListActivities(*entity.ActivityFilter, *entity.ListOptions) (*entity.List[entity.ActivityResult], error)
+	GetActivity(int64) (*entity.Activity, error)
 	CreateActivity(*entity.Activity) (*entity.Activity, error)
 	UpdateActivity(*entity.Activity) (*entity.Activity, error)
 	DeleteActivity(int64) error

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -28,6 +28,26 @@ func (h *HeurekaApp) getServiceResults(filter *entity.ServiceFilter) ([]entity.S
 	return serviceResults, nil
 }
 
+func (h *HeurekaApp) GetService(serviceId int64) (*entity.Service, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event": "app.GetService",
+		"id":    serviceId,
+	})
+	serviceFilter := entity.ServiceFilter{Id: []*int64{&serviceId}}
+	services, err := h.ListServices(&serviceFilter, &entity.ListOptions{})
+
+	if err != nil {
+		l.Error(err)
+		return nil, heurekaError("Internal error while retrieving services.")
+	}
+
+	if len(services.Elements) != 1 {
+		return nil, heurekaError(fmt.Sprintf("Service %d not found.", serviceId))
+	}
+
+	return services.Elements[0].Service, nil
+}
+
 func (h *HeurekaApp) ListServices(filter *entity.ServiceFilter, options *entity.ListOptions) (*entity.List[entity.ServiceResult], error) {
 	var count int64
 	var pageInfo *entity.PageInfo
@@ -116,19 +136,7 @@ func (h *HeurekaApp) UpdateService(service *entity.Service) (*entity.Service, er
 		return nil, heurekaError("Internal error while updating service.")
 	}
 
-	serviceResult, err := h.ListServices(&entity.ServiceFilter{Id: []*int64{&service.Id}}, &entity.ListOptions{})
-
-	if err != nil {
-		l.Error(err)
-		return nil, heurekaError("Internal error while retrieving updated service.")
-	}
-
-	if len(serviceResult.Elements) != 1 {
-		l.Error(err)
-		return nil, heurekaError("Multiple services found.")
-	}
-
-	return serviceResult.Elements[0].Service, nil
+	return h.GetService(service.Id)
 }
 
 func (h *HeurekaApp) DeleteService(id int64) error {
@@ -145,4 +153,72 @@ func (h *HeurekaApp) DeleteService(id int64) error {
 	}
 
 	return nil
+}
+
+func (h *HeurekaApp) AddOwnerToService(serviceId, ownerId int64) (*entity.Service, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":     "app.AddOwnerToService",
+		"serviceId": serviceId,
+		"ownerId":   ownerId,
+	})
+
+	err := h.database.AddOwnerToService(serviceId, ownerId)
+
+	if err != nil {
+		l.Error(err)
+		return nil, heurekaError("Internal error while adding owner to service.")
+	}
+
+	return h.GetService(serviceId)
+}
+
+func (h *HeurekaApp) RemoveOwnerFromService(serviceId, ownerId int64) (*entity.Service, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":     "app.RemoveOwnerFromService",
+		"serviceId": serviceId,
+		"ownerId":   ownerId,
+	})
+
+	err := h.database.RemoveOwnerFromService(serviceId, ownerId)
+
+	if err != nil {
+		l.Error(err)
+		return nil, heurekaError("Internal error while removing owner from service.")
+	}
+
+	return h.GetService(serviceId)
+}
+
+func (h *HeurekaApp) AddIssueRepositoryToService(serviceId, issueRepositoryId int64, priority int64) (*entity.Service, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":             "app.AddIssueRepositoryToService",
+		"serviceId":         serviceId,
+		"issueRepositoryId": issueRepositoryId,
+	})
+
+	err := h.database.AddIssueRepositoryToService(serviceId, issueRepositoryId, priority)
+
+	if err != nil {
+		l.Error(err)
+		return nil, heurekaError("Internal error while adding issue repository to service.")
+	}
+
+	return h.GetService(serviceId)
+}
+
+func (h *HeurekaApp) RemoveIssueRepositoryFromService(serviceId, issueRepositoryId int64) (*entity.Service, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":             "app.RemoveIssueRepositoryFromService",
+		"serviceId":         serviceId,
+		"issueRepositoryId": issueRepositoryId,
+	})
+
+	err := h.database.RemoveIssueRepositoryFromService(serviceId, issueRepositoryId)
+
+	if err != nil {
+		l.Error(err)
+		return nil, heurekaError("Internal error while removing issue repository from service.")
+	}
+
+	return h.GetService(serviceId)
 }

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -192,6 +192,96 @@ var _ = Describe("When deleting Service", Label("app", "DeleteService"), func() 
 		filter.Id = []*int64{&id}
 		services, err := heureka.ListServices(filter, &entity.ListOptions{})
 		Expect(err).To(BeNil(), "no error should be thrown")
-		Expect(services.Elements).To(BeEmpty(), "no error should be thrown")
+		Expect(services.Elements).To(BeEmpty(), "no services should be found")
+	})
+})
+
+var _ = Describe("When modifying owner and Service", Label("app", "OwnerService"), func() {
+	var (
+		db      *mocks.MockDatabase
+		heureka app.Heureka
+		service entity.Service
+		owner   entity.User
+		filter  *entity.ServiceFilter
+	)
+
+	BeforeEach(func() {
+		db = mocks.NewMockDatabase(GinkgoT())
+		service = test.NewFakeServiceEntity()
+		owner = test.NewFakeUserEntity()
+		first := 10
+		var after int64
+		after = 0
+		filter = &entity.ServiceFilter{
+			Paginated: entity.Paginated{
+				First: &first,
+				After: &after,
+			},
+			Id: []*int64{&service.Id},
+		}
+	})
+
+	It("adds owner to service", func() {
+		db.On("AddOwnerToService", service.Id, owner.Id).Return(nil)
+		db.On("GetServices", filter).Return([]entity.Service{service}, nil)
+		heureka = app.NewHeurekaApp(db)
+		service, err := heureka.AddOwnerToService(service.Id, owner.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(service).NotTo(BeNil(), "service should be returned")
+	})
+
+	It("removes owner from service", func() {
+		db.On("RemoveOwnerFromService", service.Id, owner.Id).Return(nil)
+		db.On("GetServices", filter).Return([]entity.Service{service}, nil)
+		heureka = app.NewHeurekaApp(db)
+		service, err := heureka.RemoveOwnerFromService(service.Id, owner.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(service).NotTo(BeNil(), "service should be returned")
+	})
+})
+
+var _ = Describe("When modifying issueRepository and Service", Label("app", "IssueRepositoryService"), func() {
+	var (
+		db              *mocks.MockDatabase
+		heureka         app.Heureka
+		service         entity.Service
+		issueRepository entity.IssueRepository
+		filter          *entity.ServiceFilter
+		priority        int64
+	)
+
+	BeforeEach(func() {
+		db = mocks.NewMockDatabase(GinkgoT())
+		service = test.NewFakeServiceEntity()
+		issueRepository = test.NewFakeIssueRepositoryEntity()
+		first := 10
+		var after int64
+		after = 0
+		filter = &entity.ServiceFilter{
+			Paginated: entity.Paginated{
+				First: &first,
+				After: &after,
+			},
+			Id: []*int64{&service.Id},
+		}
+		priority = 1
+	})
+
+	It("adds issueRepository to service", func() {
+		db.On("AddIssueRepositoryToService", service.Id, issueRepository.Id, priority).Return(nil)
+		db.On("GetServices", filter).Return([]entity.Service{service}, nil)
+		heureka = app.NewHeurekaApp(db)
+		service, err := heureka.AddIssueRepositoryToService(service.Id, issueRepository.Id, priority)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(service).NotTo(BeNil(), "service should be returned")
+	})
+
+	It("removes issueRepository from service", func() {
+		db.On("RemoveIssueRepositoryFromService", service.Id, issueRepository.Id).Return(nil)
+		db.On("GetServices", filter).Return([]entity.Service{service}, nil)
+		heureka = app.NewHeurekaApp(db)
+		service, err := heureka.RemoveIssueRepositoryFromService(service.Id, issueRepository.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(service).NotTo(BeNil(), "service should be returned")
 	})
 })

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -240,7 +240,7 @@ var _ = Describe("When modifying owner and Service", Label("app", "OwnerService"
 	})
 })
 
-var _ = Describe("When modifying issueRepository and Service", Label("app", "IssueRepositoryService"), func() {
+var _ = Describe("When modifying relationship of issueRepository and Service", Label("app", "IssueRepositoryServiceRelationship"), func() {
 	var (
 		db              *mocks.MockDatabase
 		heureka         app.Heureka

--- a/internal/app/support_group_test.go
+++ b/internal/app/support_group_test.go
@@ -192,7 +192,7 @@ var _ = Describe("When deleting SupportGroup", Label("app", "DeleteSupportGroup"
 	})
 })
 
-var _ = Describe("When modifying Service and SupportGroup", Label("app", "ServiceSupportGroup"), func() {
+var _ = Describe("When modifying relationship of Service and SupportGroup", Label("app", "ServiceSupportGroupRelationship"), func() {
 	var (
 		db           *mocks.MockDatabase
 		heureka      app.Heureka

--- a/internal/app/support_group_test.go
+++ b/internal/app/support_group_test.go
@@ -191,3 +191,47 @@ var _ = Describe("When deleting SupportGroup", Label("app", "DeleteSupportGroup"
 		Expect(supportGroups.Elements).To(BeEmpty(), "no error should be thrown")
 	})
 })
+
+var _ = Describe("When modifying Service and SupportGroup", Label("app", "ServiceSupportGroup"), func() {
+	var (
+		db           *mocks.MockDatabase
+		heureka      app.Heureka
+		service      entity.Service
+		supportGroup entity.SupportGroup
+		filter       *entity.SupportGroupFilter
+	)
+
+	BeforeEach(func() {
+		db = mocks.NewMockDatabase(GinkgoT())
+		service = test.NewFakeServiceEntity()
+		supportGroup = test.NewFakeSupportGroupEntity()
+		first := 10
+		var after int64
+		after = 0
+		filter = &entity.SupportGroupFilter{
+			Paginated: entity.Paginated{
+				First: &first,
+				After: &after,
+			},
+			Id: []*int64{&supportGroup.Id},
+		}
+	})
+
+	It("adds service to supportGroup", func() {
+		db.On("AddServiceToSupportGroup", supportGroup.Id, service.Id).Return(nil)
+		db.On("GetSupportGroups", filter).Return([]entity.SupportGroup{supportGroup}, nil)
+		heureka = app.NewHeurekaApp(db)
+		supportGroup, err := heureka.AddServiceToSupportGroup(supportGroup.Id, service.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(supportGroup).NotTo(BeNil(), "supportGroup should be returned")
+	})
+
+	It("removes service from supportGroup", func() {
+		db.On("RemoveServiceFromSupportGroup", supportGroup.Id, service.Id).Return(nil)
+		db.On("GetSupportGroups", filter).Return([]entity.SupportGroup{supportGroup}, nil)
+		heureka = app.NewHeurekaApp(db)
+		supportGroup, err := heureka.RemoveServiceFromSupportGroup(supportGroup.Id, service.Id)
+		Expect(err).To(BeNil(), "no error should be thrown")
+		Expect(supportGroup).NotTo(BeNil(), "supportGroup should be returned")
+	})
+})

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -48,6 +48,10 @@ type Database interface {
 	CreateService(*entity.Service) (*entity.Service, error)
 	UpdateService(*entity.Service) error
 	DeleteService(int64) error
+	AddOwnerToService(int64, int64) error
+	RemoveOwnerFromService(int64, int64) error
+	AddIssueRepositoryToService(int64, int64, int64) error
+	RemoveIssueRepositoryFromService(int64, int64) error
 
 	GetUsers(*entity.UserFilter) ([]entity.User, error)
 	GetAllUserIds(*entity.UserFilter) ([]int64, error)
@@ -62,6 +66,8 @@ type Database interface {
 	CreateSupportGroup(*entity.SupportGroup) (*entity.SupportGroup, error)
 	UpdateSupportGroup(*entity.SupportGroup) error
 	DeleteSupportGroup(int64) error
+	AddServiceToSupportGroup(int64, int64) error
+	RemoveServiceFromSupportGroup(int64, int64) error
 
 	GetComponentInstances(*entity.ComponentInstanceFilter) ([]entity.ComponentInstance, error)
 	GetAllComponentInstanceIds(*entity.ComponentInstanceFilter) ([]int64, error)
@@ -76,6 +82,8 @@ type Database interface {
 	CreateActivity(*entity.Activity) (*entity.Activity, error)
 	UpdateActivity(*entity.Activity) error
 	DeleteActivity(int64) error
+	AddServiceToActivity(int64, int64) error
+	RemoveServiceFromActivity(int64, int64) error
 
 	GetEvidences(*entity.EvidenceFilter) ([]entity.Evidence, error)
 	GetAllEvidenceIds(*entity.EvidenceFilter) ([]int64, error)

--- a/internal/database/mariadb/activity.go
+++ b/internal/database/mariadb/activity.go
@@ -272,3 +272,53 @@ func (s *SqlDatabase) DeleteActivity(id int64) error {
 
 	return err
 }
+
+func (s *SqlDatabase) AddServiceToActivity(activityId int64, serviceId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":  serviceId,
+		"activityId": activityId,
+		"event":      "database.AddServiceToActivity",
+	})
+
+	query := `
+		INSERT INTO ActivityHasService (
+			activityhasservice_service_id,
+			activityhasservice_activity_id
+		) VALUES (
+		 :service_id,
+		 :activity_id
+		)
+	`
+
+	args := map[string]interface{}{
+		"service_id":  serviceId,
+		"activity_id": activityId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}
+
+func (s *SqlDatabase) RemoveServiceFromActivity(activityId int64, serviceId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":  serviceId,
+		"activityId": activityId,
+		"event":      "database.RemoveServiceFromActivity",
+	})
+
+	query := `
+		DELETE FROM ActivityHasService
+		WHERE activityhasservice_service_id = :service_id
+		AND activityhasservice_activity_id = :activity_id
+	`
+
+	args := map[string]interface{}{
+		"service_id":  serviceId,
+		"activity_id": activityId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}

--- a/internal/database/mariadb/entity.go
+++ b/internal/database/mariadb/entity.go
@@ -443,7 +443,7 @@ func (bsr *BaseServiceRow) AsBaseService() entity.BaseService {
 	return entity.BaseService{
 		Id:         GetInt64Value(bsr.Id),
 		Name:       GetStringValue(bsr.Name),
-		Owner:      []entity.User{},
+		Owners:     []entity.User{},
 		Activities: []entity.Activity{},
 		CreatedAt:  GetTimeValue(bsr.CreatedAt),
 		DeletedAt:  GetTimeValue(bsr.DeletedAt),
@@ -463,7 +463,7 @@ func (sr *ServiceRow) AsService() entity.Service {
 		BaseService: entity.BaseService{
 			Id:         GetInt64Value(sr.Id),
 			Name:       GetStringValue(sr.Name),
-			Owner:      []entity.User{},
+			Owners:     []entity.User{},
 			Activities: []entity.Activity{},
 			CreatedAt:  GetTimeValue(sr.BaseServiceRow.CreatedAt),
 			DeletedAt:  GetTimeValue(sr.BaseServiceRow.DeletedAt),

--- a/internal/database/mariadb/service.go
+++ b/internal/database/mariadb/service.go
@@ -318,3 +318,106 @@ func (s *SqlDatabase) DeleteService(id int64) error {
 
 	return err
 }
+
+func (s *SqlDatabase) AddOwnerToService(serviceId int64, userId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId": serviceId,
+		"userId":    userId,
+		"event":     "database.AddOwnerToService",
+	})
+
+	query := `
+		INSERT INTO Owner (
+			owner_service_id,
+			owner_user_id
+		) VALUES (
+			:service_id,
+			:user_id
+		)
+	`
+
+	args := map[string]interface{}{
+		"service_id": serviceId,
+		"user_id":    userId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}
+
+func (s *SqlDatabase) RemoveOwnerFromService(serviceId int64, userId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId": serviceId,
+		"userId":    userId,
+		"event":     "database.RemoveOwnerFromService",
+	})
+
+	query := `
+		DELETE FROM Owner
+		WHERE owner_service_id = :service_id
+		AND owner_user_id = :user_id
+	`
+
+	args := map[string]interface{}{
+		"service_id": serviceId,
+		"user_id":    userId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}
+
+func (s *SqlDatabase) AddIssueRepositoryToService(serviceId int64, issueRepositoryId int64, priority int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":         serviceId,
+		"issueRepositoryId": issueRepositoryId,
+		"event":             "database.AddIssueRepositoryToService",
+	})
+
+	query := `
+		INSERT INTO IssueRepositoryService (
+			issuerepositoryservice_service_id,
+			issuerepositoryservice_issue_repository_id,
+			issuerepositoryservice_priority
+		) VALUES (
+		 :service_id,
+		 :issue_repository_id,
+		 :priority
+		)
+	`
+
+	args := map[string]interface{}{
+		"service_id":          serviceId,
+		"issue_repository_id": issueRepositoryId,
+		"priority":            priority,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}
+
+func (s *SqlDatabase) RemoveIssueRepositoryFromService(serviceId int64, issueRepositoryId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":         serviceId,
+		"issueRepositoryId": issueRepositoryId,
+		"event":             "database.RemoveIssueRepositoryFromService",
+	})
+
+	query := `
+		DELETE FROM IssueRepositoryService
+		WHERE issuerepositoryservice_service_id = :service_id
+		AND issuerepositoryservice_issue_repository_id = :issue_repository_id
+	`
+
+	args := map[string]interface{}{
+		"service_id":          serviceId,
+		"issue_repository_id": issueRepositoryId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}

--- a/internal/database/mariadb/service_test.go
+++ b/internal/database/mariadb/service_test.go
@@ -606,4 +606,135 @@ var _ = Describe("Service", Label("database", "Service"), func() {
 			})
 		})
 	})
+	When("Add Owner To Service", Label("AddOwnerToService"), func() {
+		Context("and we have 10 Services in the database", func() {
+			var seedCollection *test.SeedCollection
+			var newOwnerRow mariadb.UserRow
+			var newOwner entity.User
+			var owner *entity.User
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+				newOwnerRow = test.NewFakeUser()
+				newOwner = newOwnerRow.AsUser()
+				owner, _ = db.CreateUser(&newOwner)
+			})
+			It("can add owner correctly", func() {
+				service := seedCollection.ServiceRows[0].AsService()
+
+				err := db.AddOwnerToService(service.Id, owner.Id)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				serviceFilter := &entity.ServiceFilter{
+					OwnerId: []*int64{&owner.Id},
+				}
+
+				s, err := db.GetServices(serviceFilter)
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning service", func() {
+					Expect(len(s)).To(BeEquivalentTo(1))
+				})
+			})
+		})
+	})
+	When("Remove Owner From Service", Label("RemoveOwnerFromService"), func() {
+		Context("and we have 10 Services in the database", func() {
+			var seedCollection *test.SeedCollection
+			var ownerRow mariadb.OwnerRow
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+				ownerRow = seedCollection.OwnerRows[0]
+			})
+			It("can remove owner correctly", func() {
+				err := db.RemoveOwnerFromService(ownerRow.ServiceId.Int64, ownerRow.UserId.Int64)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				serviceFilter := &entity.ServiceFilter{
+					OwnerId: []*int64{&ownerRow.UserId.Int64},
+				}
+
+				services, err := db.GetServices(serviceFilter)
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				for _, s := range services {
+					Expect(s.Id).ToNot(BeEquivalentTo(ownerRow.ServiceId.Int64))
+				}
+			})
+		})
+	})
+	When("Add Issue Repository To Service", Label("AddIssueRepositoryToService"), func() {
+		Context("and we have 10 Services in the database", func() {
+			var seedCollection *test.SeedCollection
+			var newIssueRepositoryRow mariadb.IssueRepositoryRow
+			var newIssueRepository entity.IssueRepository
+			var issueRepository *entity.IssueRepository
+			var priority int64 = 1
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+				newIssueRepositoryRow = test.NewFakeIssueRepository()
+				newIssueRepository = newIssueRepositoryRow.AsIssueRepository()
+				issueRepository, _ = db.CreateIssueRepository(&newIssueRepository)
+			})
+			It("can add issue repository correctly", func() {
+				service := seedCollection.ServiceRows[0].AsService()
+
+				err := db.AddIssueRepositoryToService(service.Id, issueRepository.Id, priority)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				serviceFilter := &entity.ServiceFilter{
+					IssueRepositoryId: []*int64{&issueRepository.Id},
+				}
+
+				s, err := db.GetServices(serviceFilter)
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning service", func() {
+					Expect(len(s)).To(BeEquivalentTo(1))
+				})
+			})
+		})
+	})
+	When("Remove Issue Repository From Service", Label("RemoveIssueRepositoryFromService"), func() {
+		Context("and we have 10 Services in the database", func() {
+			var seedCollection *test.SeedCollection
+			var issueRepositoryServiceRow mariadb.IssueRepositoryServiceRow
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+				issueRepositoryServiceRow = seedCollection.IssueRepositoryServiceRows[0]
+			})
+			It("can remove issue repository correctly", func() {
+				err := db.RemoveIssueRepositoryFromService(issueRepositoryServiceRow.ServiceId.Int64, issueRepositoryServiceRow.IssueRepositoryId.Int64)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				serviceFilter := &entity.ServiceFilter{
+					IssueRepositoryId: []*int64{&issueRepositoryServiceRow.IssueRepositoryId.Int64},
+				}
+
+				services, err := db.GetServices(serviceFilter)
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				for _, s := range services {
+					Expect(s.Id).ToNot(BeEquivalentTo(issueRepositoryServiceRow.ServiceId.Int64))
+				}
+			})
+		})
+	})
 })

--- a/internal/database/mariadb/support_group.go
+++ b/internal/database/mariadb/support_group.go
@@ -270,3 +270,53 @@ func (s *SqlDatabase) DeleteSupportGroup(id int64) error {
 
 	return err
 }
+
+func (s *SqlDatabase) AddServiceToSupportGroup(supportGroupId int64, serviceId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":      serviceId,
+		"supportGroupId": supportGroupId,
+		"event":          "database.AddServiceToSupportGroup",
+	})
+
+	query := `
+		INSERT INTO SupportGroupService (
+			supportgroupservice_service_id,
+			supportgroupservice_support_group_id
+		) VALUES (
+			:service_id,
+			:support_group_id
+		)
+	`
+
+	args := map[string]interface{}{
+		"service_id":       serviceId,
+		"support_group_id": supportGroupId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}
+
+func (s *SqlDatabase) RemoveServiceFromSupportGroup(supportGroupId int64, serviceId int64) error {
+	l := logrus.WithFields(logrus.Fields{
+		"serviceId":      serviceId,
+		"supportGroupId": supportGroupId,
+		"event":          "database.RemoveServiceFromSupportGroup",
+	})
+
+	query := `
+		DELETE FROM SupportGroupService
+		WHERE supportgroupservice_service_id = :service_id
+		AND supportgroupservice_support_group_id = :support_group_id
+	`
+
+	args := map[string]interface{}{
+		"service_id":       serviceId,
+		"support_group_id": supportGroupId,
+	}
+
+	_, err := performExec(s, query, args, l)
+
+	return err
+}

--- a/internal/e2e/activity_query_test.go
+++ b/internal/e2e/activity_query_test.go
@@ -415,6 +415,7 @@ var _ = Describe("Modifying Services of Activity via API", Label("e2e", "Service
 				req := graphql.NewRequest(str)
 
 				activity := seedCollection.ActivityRows[0].AsActivity()
+				// find all services that are assigned to the activity
 				serviceIds := lo.FilterMap(seedCollection.ActivityHasServiceRows, func(row mariadb.ActivityHasServiceRow, _ int) (int64, bool) {
 					if row.ActivityId.Int64 == activity.Id {
 						return row.ServiceId.Int64, true
@@ -422,6 +423,7 @@ var _ = Describe("Modifying Services of Activity via API", Label("e2e", "Service
 					return 0, false
 				})
 
+				// find a service that is not assigned to the activity
 				serviceRow, _ := lo.Find(seedCollection.ServiceRows, func(row mariadb.BaseServiceRow) bool {
 					return !lo.Contains(serviceIds, row.Id.Int64)
 				})
@@ -459,6 +461,7 @@ var _ = Describe("Modifying Services of Activity via API", Label("e2e", "Service
 
 				activity := seedCollection.ActivityRows[0].AsActivity()
 
+				// find a service that is assigned to the activity
 				serviceRow, _ := lo.Find(seedCollection.ActivityHasServiceRows, func(row mariadb.ActivityHasServiceRow) bool {
 					return row.ActivityId.Int64 == activity.Id
 				})

--- a/internal/e2e/service_query_test.go
+++ b/internal/e2e/service_query_test.go
@@ -575,13 +575,14 @@ var _ = Describe("Modifying IssueRepository of Service via API", Label("e2e", "S
 				req := graphql.NewRequest(str)
 
 				service := seedCollection.ServiceRows[0].AsService()
+				// find all issueRepositories that are attached to the service
 				issueRepositoryIds := lo.FilterMap(seedCollection.IssueRepositoryServiceRows, func(row mariadb.IssueRepositoryServiceRow, _ int) (int64, bool) {
 					if row.ServiceId.Int64 == service.Id {
 						return row.IssueRepositoryId.Int64, true
 					}
 					return 0, false
 				})
-
+				// find an issueRepository that is not attached to the service
 				issueRepositoryRow, _ := lo.Find(seedCollection.IssueRepositoryRows, func(row mariadb.BaseIssueRepositoryRow) bool {
 					return !lo.Contains(issueRepositoryIds, row.Id.Int64)
 				})
@@ -620,6 +621,7 @@ var _ = Describe("Modifying IssueRepository of Service via API", Label("e2e", "S
 
 				service := seedCollection.ServiceRows[0].AsService()
 
+				// find an issueRepository that is attached to the service
 				issueRepositoryRow, _ := lo.Find(seedCollection.IssueRepositoryServiceRows, func(row mariadb.IssueRepositoryServiceRow) bool {
 					return row.ServiceId.Int64 == service.Id
 				})

--- a/internal/e2e/support_group_query_test.go
+++ b/internal/e2e/support_group_query_test.go
@@ -403,3 +403,118 @@ var _ = Describe("Deleting SupportGroup via API", Label("e2e", "SupportGroups"),
 		})
 	})
 })
+
+var _ = Describe("Modifying Services of SupportGroup via API", Label("e2e", "SupportGroups"), func() {
+
+	var seeder *test.DatabaseSeeder
+	var s *server.Server
+	var cfg util.Config
+
+	BeforeEach(func() {
+		var err error
+		_ = dbm.NewTestSchema()
+		seeder, err = test.NewDatabaseSeeder(dbm.DbConfig())
+		Expect(err).To(BeNil(), "Database Seeder Setup should work")
+
+		cfg = dbm.DbConfig()
+		cfg.Port = util2.GetRandomFreePort()
+		s = server.NewServer(cfg)
+
+		s.NonBlockingStart()
+	})
+
+	AfterEach(func() {
+		s.BlockingStop()
+	})
+
+	When("the database has 10 entries", func() {
+		var seedCollection *test.SeedCollection
+
+		BeforeEach(func() {
+			seedCollection = seeder.SeedDbWithNFakeData(10)
+		})
+
+		Context("and a mutation query is performed", func() {
+			It("adds service to supportGroup", Label("addService.graphql"), func() {
+				// create a queryCollection (safe to share across requests)
+				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
+
+				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
+				b, err := os.ReadFile("../api/graphql/graph/queryCollection/supportGroup/addService.graphql")
+
+				Expect(err).To(BeNil())
+				str := string(b)
+				req := graphql.NewRequest(str)
+
+				supportGroup := seedCollection.SupportGroupRows[0].AsSupportGroup()
+				serviceIds := lo.FilterMap(seedCollection.SupportGroupServiceRows, func(row mariadb.SupportGroupServiceRow, _ int) (int64, bool) {
+					if row.SupportGroupId.Int64 == supportGroup.Id {
+						return row.ServiceId.Int64, true
+					}
+					return 0, false
+				})
+
+				serviceRow, _ := lo.Find(seedCollection.ServiceRows, func(row mariadb.BaseServiceRow) bool {
+					return !lo.Contains(serviceIds, row.Id.Int64)
+				})
+
+				req.Var("supportGroupId", fmt.Sprintf("%d", supportGroup.Id))
+				req.Var("serviceId", fmt.Sprintf("%d", serviceRow.Id.Int64))
+
+				req.Header.Set("Cache-Control", "no-cache")
+				ctx := context.Background()
+
+				var respData struct {
+					SupportGroup model.SupportGroup `json:"addServiceToSupportGroup"`
+				}
+				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
+					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
+				}
+
+				_, found := lo.Find(respData.SupportGroup.Services.Edges, func(edge *model.ServiceEdge) bool {
+					return edge.Node.ID == fmt.Sprintf("%d", serviceRow.Id.Int64)
+				})
+
+				Expect(respData.SupportGroup.ID).To(Equal(fmt.Sprintf("%d", supportGroup.Id)))
+				Expect(found).To(BeTrue())
+			})
+			It("removes service from supportGroup", Label("removeService.graphql"), func() {
+				// create a queryCollection (safe to share across requests)
+				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
+
+				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
+				b, err := os.ReadFile("../api/graphql/graph/queryCollection/supportGroup/removeService.graphql")
+
+				Expect(err).To(BeNil())
+				str := string(b)
+				req := graphql.NewRequest(str)
+
+				supportGroup := seedCollection.SupportGroupRows[0].AsSupportGroup()
+
+				serviceRow, _ := lo.Find(seedCollection.SupportGroupServiceRows, func(row mariadb.SupportGroupServiceRow) bool {
+					return row.SupportGroupId.Int64 == supportGroup.Id
+				})
+
+				req.Var("supportGroupId", fmt.Sprintf("%d", supportGroup.Id))
+				req.Var("serviceId", fmt.Sprintf("%d", serviceRow.ServiceId.Int64))
+
+				req.Header.Set("Cache-Control", "no-cache")
+				ctx := context.Background()
+
+				var respData struct {
+					SupportGroup model.SupportGroup `json:"removeServiceFromSupportGroup"`
+				}
+				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
+					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
+				}
+
+				_, found := lo.Find(respData.SupportGroup.Services.Edges, func(edge *model.ServiceEdge) bool {
+					return edge.Node.ID == fmt.Sprintf("%d", serviceRow.ServiceId.Int64)
+				})
+
+				Expect(respData.SupportGroup.ID).To(Equal(fmt.Sprintf("%d", supportGroup.Id)))
+				Expect(found).To(BeFalse())
+			})
+		})
+	})
+})

--- a/internal/e2e/support_group_query_test.go
+++ b/internal/e2e/support_group_query_test.go
@@ -447,6 +447,7 @@ var _ = Describe("Modifying Services of SupportGroup via API", Label("e2e", "Sup
 				req := graphql.NewRequest(str)
 
 				supportGroup := seedCollection.SupportGroupRows[0].AsSupportGroup()
+				// find all services that are attached to the supportGroup
 				serviceIds := lo.FilterMap(seedCollection.SupportGroupServiceRows, func(row mariadb.SupportGroupServiceRow, _ int) (int64, bool) {
 					if row.SupportGroupId.Int64 == supportGroup.Id {
 						return row.ServiceId.Int64, true
@@ -454,6 +455,7 @@ var _ = Describe("Modifying Services of SupportGroup via API", Label("e2e", "Sup
 					return 0, false
 				})
 
+				// find a service that is not attached to the supportGroup
 				serviceRow, _ := lo.Find(seedCollection.ServiceRows, func(row mariadb.BaseServiceRow) bool {
 					return !lo.Contains(serviceIds, row.Id.Int64)
 				})
@@ -491,6 +493,7 @@ var _ = Describe("Modifying Services of SupportGroup via API", Label("e2e", "Sup
 
 				supportGroup := seedCollection.SupportGroupRows[0].AsSupportGroup()
 
+				// find a service that is attached to the supportGroup
 				serviceRow, _ := lo.Find(seedCollection.SupportGroupServiceRows, func(row mariadb.SupportGroupServiceRow) bool {
 					return row.SupportGroupId.Int64 == supportGroup.Id
 				})

--- a/internal/entity/service.go
+++ b/internal/entity/service.go
@@ -10,7 +10,7 @@ type BaseService struct {
 	Name           string        `json:"name"`
 	SupportGroup   *SupportGroup `json:"support_group,omitempty"`
 	SupportGroupId int64         `db:"service_support_group_id"`
-	Owner          []User        `json:"owners,omitempty"`
+	Owners         []User        `json:"owners,omitempty"`
 	Activities     []Activity    `json:"activities,omitempty"`
 	Priority       int64         `json:"priority"`
 	CreatedAt      time.Time     `json:"created_at"`

--- a/internal/entity/test/service.go
+++ b/internal/entity/test/service.go
@@ -15,7 +15,7 @@ func NewFakeServiceEntity() entity.Service {
 			Name:         gofakeit.Name(),
 			SupportGroup: nil,
 			Activities:   nil,
-			Owner:        nil,
+			Owners:       nil,
 			CreatedAt:    gofakeit.Date(),
 			DeletedAt:    gofakeit.Date(),
 			UpdatedAt:    gofakeit.Date(),

--- a/internal/mocks/mock_Database.go
+++ b/internal/mocks/mock_Database.go
@@ -23,6 +23,195 @@ func (_m *MockDatabase) EXPECT() *MockDatabase_Expecter {
 	return &MockDatabase_Expecter{mock: &_m.Mock}
 }
 
+// AddIssueRepositoryToService provides a mock function with given fields: _a0, _a1, _a2
+func (_m *MockDatabase) AddIssueRepositoryToService(_a0 int64, _a1 int64, _a2 int64) error {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddIssueRepositoryToService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64, int64) error); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_AddIssueRepositoryToService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddIssueRepositoryToService'
+type MockDatabase_AddIssueRepositoryToService_Call struct {
+	*mock.Call
+}
+
+// AddIssueRepositoryToService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+//   - _a2 int64
+func (_e *MockDatabase_Expecter) AddIssueRepositoryToService(_a0 interface{}, _a1 interface{}, _a2 interface{}) *MockDatabase_AddIssueRepositoryToService_Call {
+	return &MockDatabase_AddIssueRepositoryToService_Call{Call: _e.mock.On("AddIssueRepositoryToService", _a0, _a1, _a2)}
+}
+
+func (_c *MockDatabase_AddIssueRepositoryToService_Call) Run(run func(_a0 int64, _a1 int64, _a2 int64)) *MockDatabase_AddIssueRepositoryToService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64), args[2].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_AddIssueRepositoryToService_Call) Return(_a0 error) *MockDatabase_AddIssueRepositoryToService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_AddIssueRepositoryToService_Call) RunAndReturn(run func(int64, int64, int64) error) *MockDatabase_AddIssueRepositoryToService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddOwnerToService provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) AddOwnerToService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddOwnerToService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_AddOwnerToService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddOwnerToService'
+type MockDatabase_AddOwnerToService_Call struct {
+	*mock.Call
+}
+
+// AddOwnerToService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) AddOwnerToService(_a0 interface{}, _a1 interface{}) *MockDatabase_AddOwnerToService_Call {
+	return &MockDatabase_AddOwnerToService_Call{Call: _e.mock.On("AddOwnerToService", _a0, _a1)}
+}
+
+func (_c *MockDatabase_AddOwnerToService_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_AddOwnerToService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_AddOwnerToService_Call) Return(_a0 error) *MockDatabase_AddOwnerToService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_AddOwnerToService_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_AddOwnerToService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddServiceToActivity provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) AddServiceToActivity(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddServiceToActivity")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_AddServiceToActivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddServiceToActivity'
+type MockDatabase_AddServiceToActivity_Call struct {
+	*mock.Call
+}
+
+// AddServiceToActivity is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) AddServiceToActivity(_a0 interface{}, _a1 interface{}) *MockDatabase_AddServiceToActivity_Call {
+	return &MockDatabase_AddServiceToActivity_Call{Call: _e.mock.On("AddServiceToActivity", _a0, _a1)}
+}
+
+func (_c *MockDatabase_AddServiceToActivity_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_AddServiceToActivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_AddServiceToActivity_Call) Return(_a0 error) *MockDatabase_AddServiceToActivity_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_AddServiceToActivity_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_AddServiceToActivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddServiceToSupportGroup provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) AddServiceToSupportGroup(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddServiceToSupportGroup")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_AddServiceToSupportGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddServiceToSupportGroup'
+type MockDatabase_AddServiceToSupportGroup_Call struct {
+	*mock.Call
+}
+
+// AddServiceToSupportGroup is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) AddServiceToSupportGroup(_a0 interface{}, _a1 interface{}) *MockDatabase_AddServiceToSupportGroup_Call {
+	return &MockDatabase_AddServiceToSupportGroup_Call{Call: _e.mock.On("AddServiceToSupportGroup", _a0, _a1)}
+}
+
+func (_c *MockDatabase_AddServiceToSupportGroup_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_AddServiceToSupportGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_AddServiceToSupportGroup_Call) Return(_a0 error) *MockDatabase_AddServiceToSupportGroup_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_AddServiceToSupportGroup_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_AddServiceToSupportGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CloseConnection provides a mock function with given fields:
 func (_m *MockDatabase) CloseConnection() error {
 	ret := _m.Called()
@@ -3710,6 +3899,194 @@ func (_c *MockDatabase_GetUsers_Call) Return(_a0 []entity.User, _a1 error) *Mock
 }
 
 func (_c *MockDatabase_GetUsers_Call) RunAndReturn(run func(*entity.UserFilter) ([]entity.User, error)) *MockDatabase_GetUsers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveIssueRepositoryFromService provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) RemoveIssueRepositoryFromService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveIssueRepositoryFromService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_RemoveIssueRepositoryFromService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveIssueRepositoryFromService'
+type MockDatabase_RemoveIssueRepositoryFromService_Call struct {
+	*mock.Call
+}
+
+// RemoveIssueRepositoryFromService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) RemoveIssueRepositoryFromService(_a0 interface{}, _a1 interface{}) *MockDatabase_RemoveIssueRepositoryFromService_Call {
+	return &MockDatabase_RemoveIssueRepositoryFromService_Call{Call: _e.mock.On("RemoveIssueRepositoryFromService", _a0, _a1)}
+}
+
+func (_c *MockDatabase_RemoveIssueRepositoryFromService_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_RemoveIssueRepositoryFromService_Call) Return(_a0 error) *MockDatabase_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_RemoveIssueRepositoryFromService_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveOwnerFromService provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) RemoveOwnerFromService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveOwnerFromService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_RemoveOwnerFromService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveOwnerFromService'
+type MockDatabase_RemoveOwnerFromService_Call struct {
+	*mock.Call
+}
+
+// RemoveOwnerFromService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) RemoveOwnerFromService(_a0 interface{}, _a1 interface{}) *MockDatabase_RemoveOwnerFromService_Call {
+	return &MockDatabase_RemoveOwnerFromService_Call{Call: _e.mock.On("RemoveOwnerFromService", _a0, _a1)}
+}
+
+func (_c *MockDatabase_RemoveOwnerFromService_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_RemoveOwnerFromService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_RemoveOwnerFromService_Call) Return(_a0 error) *MockDatabase_RemoveOwnerFromService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_RemoveOwnerFromService_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_RemoveOwnerFromService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveServiceFromActivity provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) RemoveServiceFromActivity(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveServiceFromActivity")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_RemoveServiceFromActivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveServiceFromActivity'
+type MockDatabase_RemoveServiceFromActivity_Call struct {
+	*mock.Call
+}
+
+// RemoveServiceFromActivity is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) RemoveServiceFromActivity(_a0 interface{}, _a1 interface{}) *MockDatabase_RemoveServiceFromActivity_Call {
+	return &MockDatabase_RemoveServiceFromActivity_Call{Call: _e.mock.On("RemoveServiceFromActivity", _a0, _a1)}
+}
+
+func (_c *MockDatabase_RemoveServiceFromActivity_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_RemoveServiceFromActivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_RemoveServiceFromActivity_Call) Return(_a0 error) *MockDatabase_RemoveServiceFromActivity_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_RemoveServiceFromActivity_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_RemoveServiceFromActivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveServiceFromSupportGroup provides a mock function with given fields: _a0, _a1
+func (_m *MockDatabase) RemoveServiceFromSupportGroup(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveServiceFromSupportGroup")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDatabase_RemoveServiceFromSupportGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveServiceFromSupportGroup'
+type MockDatabase_RemoveServiceFromSupportGroup_Call struct {
+	*mock.Call
+}
+
+// RemoveServiceFromSupportGroup is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockDatabase_Expecter) RemoveServiceFromSupportGroup(_a0 interface{}, _a1 interface{}) *MockDatabase_RemoveServiceFromSupportGroup_Call {
+	return &MockDatabase_RemoveServiceFromSupportGroup_Call{Call: _e.mock.On("RemoveServiceFromSupportGroup", _a0, _a1)}
+}
+
+func (_c *MockDatabase_RemoveServiceFromSupportGroup_Call) Run(run func(_a0 int64, _a1 int64)) *MockDatabase_RemoveServiceFromSupportGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDatabase_RemoveServiceFromSupportGroup_Call) Return(_a0 error) *MockDatabase_RemoveServiceFromSupportGroup_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDatabase_RemoveServiceFromSupportGroup_Call) RunAndReturn(run func(int64, int64) error) *MockDatabase_RemoveServiceFromSupportGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/mocks/mock_Heureka.go
+++ b/internal/mocks/mock_Heureka.go
@@ -23,6 +23,100 @@ func (_m *MockHeureka) EXPECT() *MockHeureka_Expecter {
 	return &MockHeureka_Expecter{mock: &_m.Mock}
 }
 
+// AddIssueRepositoryToService provides a mock function with given fields: _a0, _a1
+func (_m *MockHeureka) AddIssueRepositoryToService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddIssueRepositoryToService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockHeureka_AddIssueRepositoryToService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddIssueRepositoryToService'
+type MockHeureka_AddIssueRepositoryToService_Call struct {
+	*mock.Call
+}
+
+// AddIssueRepositoryToService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockHeureka_Expecter) AddIssueRepositoryToService(_a0 interface{}, _a1 interface{}) *MockHeureka_AddIssueRepositoryToService_Call {
+	return &MockHeureka_AddIssueRepositoryToService_Call{Call: _e.mock.On("AddIssueRepositoryToService", _a0, _a1)}
+}
+
+func (_c *MockHeureka_AddIssueRepositoryToService_Call) Run(run func(_a0 int64, _a1 int64)) *MockHeureka_AddIssueRepositoryToService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_AddIssueRepositoryToService_Call) Return(_a0 error) *MockHeureka_AddIssueRepositoryToService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHeureka_AddIssueRepositoryToService_Call) RunAndReturn(run func(int64, int64) error) *MockHeureka_AddIssueRepositoryToService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddOwnerToService provides a mock function with given fields: _a0, _a1
+func (_m *MockHeureka) AddOwnerToService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddOwnerToService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockHeureka_AddOwnerToService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddOwnerToService'
+type MockHeureka_AddOwnerToService_Call struct {
+	*mock.Call
+}
+
+// AddOwnerToService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockHeureka_Expecter) AddOwnerToService(_a0 interface{}, _a1 interface{}) *MockHeureka_AddOwnerToService_Call {
+	return &MockHeureka_AddOwnerToService_Call{Call: _e.mock.On("AddOwnerToService", _a0, _a1)}
+}
+
+func (_c *MockHeureka_AddOwnerToService_Call) Run(run func(_a0 int64, _a1 int64)) *MockHeureka_AddOwnerToService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_AddOwnerToService_Call) Return(_a0 error) *MockHeureka_AddOwnerToService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHeureka_AddOwnerToService_Call) RunAndReturn(run func(int64, int64) error) *MockHeureka_AddOwnerToService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateActivity provides a mock function with given fields: _a0
 func (_m *MockHeureka) CreateActivity(_a0 *entity.Activity) (*entity.Activity, error) {
 	ret := _m.Called(_a0)
@@ -425,6 +519,64 @@ func (_c *MockHeureka_CreateIssueMatch_Call) Return(_a0 *entity.IssueMatch, _a1 
 }
 
 func (_c *MockHeureka_CreateIssueMatch_Call) RunAndReturn(run func(*entity.IssueMatch) (*entity.IssueMatch, error)) *MockHeureka_CreateIssueMatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateIssueMatchChange provides a mock function with given fields: _a0
+func (_m *MockHeureka) CreateIssueMatchChange(_a0 *entity.IssueMatchChange) (*entity.IssueMatchChange, error) {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateIssueMatchChange")
+	}
+
+	var r0 *entity.IssueMatchChange
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*entity.IssueMatchChange) (*entity.IssueMatchChange, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(*entity.IssueMatchChange) *entity.IssueMatchChange); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.IssueMatchChange)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*entity.IssueMatchChange) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockHeureka_CreateIssueMatchChange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateIssueMatchChange'
+type MockHeureka_CreateIssueMatchChange_Call struct {
+	*mock.Call
+}
+
+// CreateIssueMatchChange is a helper method to define mock.On call
+//   - _a0 *entity.IssueMatchChange
+func (_e *MockHeureka_Expecter) CreateIssueMatchChange(_a0 interface{}) *MockHeureka_CreateIssueMatchChange_Call {
+	return &MockHeureka_CreateIssueMatchChange_Call{Call: _e.mock.On("CreateIssueMatchChange", _a0)}
+}
+
+func (_c *MockHeureka_CreateIssueMatchChange_Call) Run(run func(_a0 *entity.IssueMatchChange)) *MockHeureka_CreateIssueMatchChange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*entity.IssueMatchChange))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_CreateIssueMatchChange_Call) Return(_a0 *entity.IssueMatchChange, _a1 error) *MockHeureka_CreateIssueMatchChange_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockHeureka_CreateIssueMatchChange_Call) RunAndReturn(run func(*entity.IssueMatchChange) (*entity.IssueMatchChange, error)) *MockHeureka_CreateIssueMatchChange_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1037,6 +1189,52 @@ func (_c *MockHeureka_DeleteIssueMatch_Call) Return(_a0 error) *MockHeureka_Dele
 }
 
 func (_c *MockHeureka_DeleteIssueMatch_Call) RunAndReturn(run func(int64) error) *MockHeureka_DeleteIssueMatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteIssueMatchChange provides a mock function with given fields: _a0
+func (_m *MockHeureka) DeleteIssueMatchChange(_a0 int64) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteIssueMatchChange")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockHeureka_DeleteIssueMatchChange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteIssueMatchChange'
+type MockHeureka_DeleteIssueMatchChange_Call struct {
+	*mock.Call
+}
+
+// DeleteIssueMatchChange is a helper method to define mock.On call
+//   - _a0 int64
+func (_e *MockHeureka_Expecter) DeleteIssueMatchChange(_a0 interface{}) *MockHeureka_DeleteIssueMatchChange_Call {
+	return &MockHeureka_DeleteIssueMatchChange_Call{Call: _e.mock.On("DeleteIssueMatchChange", _a0)}
+}
+
+func (_c *MockHeureka_DeleteIssueMatchChange_Call) Run(run func(_a0 int64)) *MockHeureka_DeleteIssueMatchChange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_DeleteIssueMatchChange_Call) Return(_a0 error) *MockHeureka_DeleteIssueMatchChange_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHeureka_DeleteIssueMatchChange_Call) RunAndReturn(run func(int64) error) *MockHeureka_DeleteIssueMatchChange_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2155,6 +2353,100 @@ func (_c *MockHeureka_ListUsers_Call) RunAndReturn(run func(*entity.UserFilter, 
 	return _c
 }
 
+// RemoveIssueRepositoryFromService provides a mock function with given fields: _a0, _a1
+func (_m *MockHeureka) RemoveIssueRepositoryFromService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveIssueRepositoryFromService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockHeureka_RemoveIssueRepositoryFromService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveIssueRepositoryFromService'
+type MockHeureka_RemoveIssueRepositoryFromService_Call struct {
+	*mock.Call
+}
+
+// RemoveIssueRepositoryFromService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockHeureka_Expecter) RemoveIssueRepositoryFromService(_a0 interface{}, _a1 interface{}) *MockHeureka_RemoveIssueRepositoryFromService_Call {
+	return &MockHeureka_RemoveIssueRepositoryFromService_Call{Call: _e.mock.On("RemoveIssueRepositoryFromService", _a0, _a1)}
+}
+
+func (_c *MockHeureka_RemoveIssueRepositoryFromService_Call) Run(run func(_a0 int64, _a1 int64)) *MockHeureka_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_RemoveIssueRepositoryFromService_Call) Return(_a0 error) *MockHeureka_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHeureka_RemoveIssueRepositoryFromService_Call) RunAndReturn(run func(int64, int64) error) *MockHeureka_RemoveIssueRepositoryFromService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveOwnerFromService provides a mock function with given fields: _a0, _a1
+func (_m *MockHeureka) RemoveOwnerFromService(_a0 int64, _a1 int64) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveOwnerFromService")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, int64) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockHeureka_RemoveOwnerFromService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveOwnerFromService'
+type MockHeureka_RemoveOwnerFromService_Call struct {
+	*mock.Call
+}
+
+// RemoveOwnerFromService is a helper method to define mock.On call
+//   - _a0 int64
+//   - _a1 int64
+func (_e *MockHeureka_Expecter) RemoveOwnerFromService(_a0 interface{}, _a1 interface{}) *MockHeureka_RemoveOwnerFromService_Call {
+	return &MockHeureka_RemoveOwnerFromService_Call{Call: _e.mock.On("RemoveOwnerFromService", _a0, _a1)}
+}
+
+func (_c *MockHeureka_RemoveOwnerFromService_Call) Run(run func(_a0 int64, _a1 int64)) *MockHeureka_RemoveOwnerFromService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_RemoveOwnerFromService_Call) Return(_a0 error) *MockHeureka_RemoveOwnerFromService_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHeureka_RemoveOwnerFromService_Call) RunAndReturn(run func(int64, int64) error) *MockHeureka_RemoveOwnerFromService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Shutdown provides a mock function with given fields:
 func (_m *MockHeureka) Shutdown() error {
 	ret := _m.Called()
@@ -2602,6 +2894,64 @@ func (_c *MockHeureka_UpdateIssueMatch_Call) Return(_a0 *entity.IssueMatch, _a1 
 }
 
 func (_c *MockHeureka_UpdateIssueMatch_Call) RunAndReturn(run func(*entity.IssueMatch) (*entity.IssueMatch, error)) *MockHeureka_UpdateIssueMatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateIssueMatchChange provides a mock function with given fields: _a0
+func (_m *MockHeureka) UpdateIssueMatchChange(_a0 *entity.IssueMatchChange) (*entity.IssueMatchChange, error) {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateIssueMatchChange")
+	}
+
+	var r0 *entity.IssueMatchChange
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*entity.IssueMatchChange) (*entity.IssueMatchChange, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(*entity.IssueMatchChange) *entity.IssueMatchChange); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.IssueMatchChange)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*entity.IssueMatchChange) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockHeureka_UpdateIssueMatchChange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateIssueMatchChange'
+type MockHeureka_UpdateIssueMatchChange_Call struct {
+	*mock.Call
+}
+
+// UpdateIssueMatchChange is a helper method to define mock.On call
+//   - _a0 *entity.IssueMatchChange
+func (_e *MockHeureka_Expecter) UpdateIssueMatchChange(_a0 interface{}) *MockHeureka_UpdateIssueMatchChange_Call {
+	return &MockHeureka_UpdateIssueMatchChange_Call{Call: _e.mock.On("UpdateIssueMatchChange", _a0)}
+}
+
+func (_c *MockHeureka_UpdateIssueMatchChange_Call) Run(run func(_a0 *entity.IssueMatchChange)) *MockHeureka_UpdateIssueMatchChange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*entity.IssueMatchChange))
+	})
+	return _c
+}
+
+func (_c *MockHeureka_UpdateIssueMatchChange_Call) Return(_a0 *entity.IssueMatchChange, _a1 error) *MockHeureka_UpdateIssueMatchChange_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockHeureka_UpdateIssueMatchChange_Call) RunAndReturn(run func(*entity.IssueMatchChange) (*entity.IssueMatchChange, error)) *MockHeureka_UpdateIssueMatchChange_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Adds the following mutations:
```
    addServiceToSupportGroup(supportGroupId: ID!, serviceId: ID!): SupportGroup!
    removeServiceFromSupportGroup(supportGroupId: ID!, serviceId: ID!): SupportGroup!
    addOwnerToService(serviceId: ID!, userId: ID!): Service!
    removeOwnerFromService(serviceId: ID!, userId: ID!): Service!
    addIssueRepositoryToService(serviceId: ID!, issueRepositoryId: ID!, priority: Int!): Service!
    removeIssueRepositoryFromService(serviceId: ID!, issueRepositoryId: ID!): Service!
    addServiceToActivity(activityId: ID!, serviceId: ID!): Activity!
    removeServiceFromActivity(activityId: ID!, serviceId: ID!): Activity!
```