### PR TITLE
fix: fetch sub-manifests from keppel

### DIFF
--- a/scanner/keppel/main.go
+++ b/scanner/keppel/main.go
@@ -148,13 +148,13 @@ func HandleRepository(fqdn string, account models.Account, repository models.Rep
 }
 
 func HandleManifest(account models.Account, repository models.Repository, manifest models.Manifest, component *client.Component, keppelScanner *scanner.Scanner, keppelProcessor *processor.Processor) {
-	childManifests, err := keppelScanner.ListManifestsOfManifest(account.Name, repository.Name, manifest.Digest)
+	childManifests, err := keppelScanner.ListChildManifests(account.Name, repository.Name, manifest.Digest)
 
 	if err != nil {
 		log.WithFields(log.Fields{
 			"account:":   account.Name,
 			"repository": repository.Name,
-		}).WithError(err).Error("Error during ListManifestsOfManifest")
+		}).WithError(err).Error("Error during ListChildManifests")
 	}
 
 	componentVersion, err := keppelProcessor.ProcessManifest(manifest, component.Id)

--- a/scanner/keppel/main.go
+++ b/scanner/keppel/main.go
@@ -164,14 +164,7 @@ func HandleManifest(account models.Account, repository models.Repository, manife
 			"repository": repository.Name,
 		}).WithError(err).Error("Error during ProcessManifest")
 		componentVersion, err = keppelProcessor.GetComponentVersion(manifest.Digest)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"account:":   account.Name,
-				"repository": repository.Name,
-			}).WithError(err).Error("Error during GetComponentVersion")
-			return
-		}
-		if componentVersion == nil {
+		if err != nil || componentVersion == nil {
 			log.WithFields(log.Fields{
 				"account:":   account.Name,
 				"repository": repository.Name,

--- a/scanner/keppel/processor/processor.go
+++ b/scanner/keppel/processor/processor.go
@@ -53,6 +53,7 @@ func (p *Processor) ProcessManifest(manifest models.Manifest, componentId string
 	})
 
 	if err != nil {
+		log.WithError(err).Error("Error while creating component")
 		return nil, err
 	}
 

--- a/scanner/keppel/scanner/scanner.go
+++ b/scanner/keppel/scanner/scanner.go
@@ -156,7 +156,15 @@ func (s *Scanner) ListManifests(account string, repository string) ([]models.Man
 	return manifestResponse.Manifests, nil
 }
 
-func (s *Scanner) ListManifestsOfManifest(account string, repository string, manifest string) ([]models.Manifest, error) {
+// ListChildManifests is requred asa on Keppel not all Images are including vulnerability scan results directly on the
+// top layer of the image and rather have the scan results on the child manifests. An prime example of this are multi-arch
+// images where the scan results are  available on the child manifests with the respective concrete architecture.
+// This method is using the v2 API endpoint as on the v1 of the API the child manifests listing is not available.
+//
+// Note: The v2 API does return slightly different results and therefore some of the fileds of models.Manifest are unset.
+// This fact is accepted and no additional struct for parsing all information is implemented at this point in time
+// as the additional available information is currently not utilized.
+func (s *Scanner) ListChildManifests(account string, repository string, manifest string) ([]models.Manifest, error) {
 	url := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", s.KeppelBaseUrl, account, repository, manifest)
 	body, err := s.sendRequest(url, s.AuthToken)
 	if err != nil {


### PR DESCRIPTION
## Description

Keppel does not scan in all cases the top layer of an image. The primary cause of that is multi-arch images. In such cases we need to list all manifests of the manifest and check for vulnerabilities on those.

In perspective, we need to decide if that is as well stored in different versions that are related to each other instead.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

#247 

## Added tests?

- [ ] 👍 yes
- [] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [x] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
