### PR TITLE
chore: update build_query in codeql.yaml

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,22 +9,7 @@ on:
     - cron: '20 08 * * 1'
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.22
-
-      - name: Install mockery
-        run: go install github.com/vektra/mockery/v2@v2.46.3
-
   codeql:
-    needs: setup
     uses: cloudoperators/common/.github/workflows/shared-codeql.yaml@main
     permissions:
       security-events: write
@@ -40,4 +25,4 @@ jobs:
       fail-fast: false  
       # timeout: 30
       autobuild: false
-      build_query: "make build-binary"
+      build_query: "go install github.com/vektra/mockery/v2@v2.46.3 && make build-binary"


### PR DESCRIPTION
## Description

The `setup` and `codeql` jobs run independently, so the `mockery` command is not found in the `codeql` job. Therefore, install it through the custom `build_query`

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
