### PR TITLE
feat(issueVariant): add filter by secondaryName in baseResolver

### DIFF
--- a/internal/api/graphql/graph/baseResolver/issue_variant.go
+++ b/internal/api/graphql/graph/baseResolver/issue_variant.go
@@ -92,6 +92,7 @@ func IssueVariantBaseResolver(app app.Heureka, ctx context.Context, filter *mode
 		Paginated:         entity.Paginated{First: first, After: afterId},
 		IssueId:           issueId,
 		IssueRepositoryId: irId,
+		SecondaryName:     filter.SecondaryName,
 	}
 
 	opt := GetListOptions(requestedFields)

--- a/internal/database/mariadb/issue_variant_test.go
+++ b/internal/database/mariadb/issue_variant_test.go
@@ -309,6 +309,27 @@ var _ = Describe("IssueVariant - ", Label("database", "IssueVariant"), func() {
 						}
 					})
 				})
+				It("can filter by a secondary name", func() {
+					iv := seedCollection.IssueVariantRows[rand.Intn(len(seedCollection.IssueVariantRows))]
+
+					filter := &entity.IssueVariantFilter{
+						SecondaryName: []*string{&iv.SecondaryName.String},
+					}
+
+					entries, err := db.GetIssueVariants(filter)
+
+					By("throwing no error", func() {
+						Expect(err).To(BeNil())
+					})
+
+					By("returning expected number of results", func() {
+						Expect(entries).To(HaveLen(1))
+					})
+
+					By("returning expected elements", func() {
+						Expect(entries[0].SecondaryName).To(BeEquivalentTo(iv.SecondaryName.String))
+					})
+				})
 			})
 			Context("and using Pagination", func() {
 				DescribeTable("can correctly paginate", func(pageSize int) {


### PR DESCRIPTION
## Description

Add the `secondaryName` to the filter building in the `IssueVariant` BaseResolver, so that filtering via API is possible.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #373

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
