### PR TITLE
ci(keppel): seperate user and keppel domain

### DIFF
--- a/scanner/keppel/chart/keppel-scanner/templates/cronjob.yaml
+++ b/scanner/keppel/chart/keppel-scanner/templates/cronjob.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.scanner.keppel.domain }}
             - name: KEPPEL_PROJECT
               value: {{ .Values.scanner.keppel.project }}
+            - name: KEPPEL_JUSER_DOMAIN
+              value: {{ .Values.scanner.keppel.user_domain }}
             - name: HEUREKA_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/scanner/keppel/chart/keppel-scanner/templates/cronjob.yaml
+++ b/scanner/keppel/chart/keppel-scanner/templates/cronjob.yaml
@@ -42,7 +42,7 @@ spec:
               value: {{ .Values.scanner.keppel.domain }}
             - name: KEPPEL_PROJECT
               value: {{ .Values.scanner.keppel.project }}
-            - name: KEPPEL_JUSER_DOMAIN
+            - name: KEPPEL_USER_DOMAIN
               value: {{ .Values.scanner.keppel.user_domain }}
             - name: HEUREKA_API_TOKEN
               valueFrom:

--- a/scanner/keppel/chart/keppel-scanner/values.yaml
+++ b/scanner/keppel/chart/keppel-scanner/values.yaml
@@ -4,6 +4,7 @@
 # Default values for keppel-scanner.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
 scanner:
   api_token: ""
   heureka_url: ""
@@ -14,6 +15,7 @@ scanner:
     fqdn: ""
     domain: ""
     project: ""
+    user_domain: ""
   identity_endpoint: ""
 
 

--- a/scanner/keppel/scanner/config.go
+++ b/scanner/keppel/scanner/config.go
@@ -8,6 +8,7 @@ import "fmt"
 type Config struct {
 	KeppelFQDN       string `envconfig:"KEPPEL_FQDN" required:"true" json:"-"`
 	KeppelUsername   string `envconfig:"KEPPEL_USERNAME" required:"true" json:"-"`
+	KeppelUserDomain string `envconfig:"KEPPEL_USER_DOMAIN" required:"true" json:"-"`
 	KeppelPassword   string `envconfig:"KEPPEL_PASSWORD" required:"true" json:"-"`
 	Domain           string `envconfig:"KEPPEL_DOMAIN" required:"true" json:"-"`
 	Project          string `envconfig:"KEPPEL_PROJECT" required:"true" json:"-"`

--- a/scanner/keppel/scanner/scanner.go
+++ b/scanner/keppel/scanner/scanner.go
@@ -29,6 +29,7 @@ type Scanner struct {
 	KeppelBaseUrl    string
 	IdentityEndpoint string
 	Username         string
+	UserDomain       string
 	Password         string
 	AuthToken        string
 	Domain           string
@@ -49,6 +50,7 @@ func NewScanner(cfg Config) *Scanner {
 		Username:         cfg.KeppelUsername,
 		Password:         cfg.KeppelPassword,
 		Domain:           cfg.Domain,
+		UserDomain:       cfg.KeppelUserDomain,
 		Project:          cfg.Project,
 		IdentityEndpoint: cfg.IdentityEndpoint,
 	}
@@ -84,7 +86,7 @@ func (s *Scanner) newAuthenticatedProviderClient() (*gophercloud.ProviderClient,
 		IdentityEndpoint: s.IdentityEndpoint,
 		Username:         s.Username,
 		Password:         s.Password,
-		DomainName:       s.Domain,
+		DomainName:       s.UserDomain,
 		AllowReauth:      true,
 		Scope: tokens.Scope{
 			ProjectName: s.Project,


### PR DESCRIPTION
## Description

Separated User Domain from Keppel Domain, to allow authentication with a user that is living in a different domain then keppel itself.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

#391 