### PR TITLE
feat(issueMatch): add serviceOwner filter

### DIFF
--- a/internal/api/graphql/graph/baseResolver/issue_match.go
+++ b/internal/api/graphql/graph/baseResolver/issue_match.go
@@ -100,21 +100,23 @@ func IssueMatchBaseResolver(app app.Heureka, ctx context.Context, filter *model.
 	}
 
 	f := &entity.IssueMatchFilter{
-		Id:                  issue_match_ids,
-		PaginatedX:          entity.PaginatedX{First: first, After: after},
-		ServiceCCRN:         filter.ServiceCcrn,
-		Status:              lo.Map(filter.Status, func(item *model.IssueMatchStatusValues, _ int) *string { return pointer.String(item.String()) }),
-		SeverityValue:       lo.Map(filter.Severity, func(item *model.SeverityValues, _ int) *string { return pointer.String(item.String()) }),
-		SupportGroupCCRN:    filter.SupportGroupCcrn,
-		IssueId:             issueId,
-		EvidenceId:          eId,
-		ServiceId:           serviceId,
-		ComponentInstanceId: ciId,
-		Search:              filter.Search,
-		ComponentCCRN:       filter.ComponentCcrn,
-		PrimaryName:         filter.PrimaryName,
-		IssueType:           lo.Map(filter.IssueType, func(item *model.IssueTypes, _ int) *string { return pointer.String(item.String()) }),
-		State:               model.GetStateFilterType(filter.State),
+		Id:                       issue_match_ids,
+		PaginatedX:               entity.PaginatedX{First: first, After: after},
+		ServiceCCRN:              filter.ServiceCcrn,
+		Status:                   lo.Map(filter.Status, func(item *model.IssueMatchStatusValues, _ int) *string { return pointer.String(item.String()) }),
+		SeverityValue:            lo.Map(filter.Severity, func(item *model.SeverityValues, _ int) *string { return pointer.String(item.String()) }),
+		SupportGroupCCRN:         filter.SupportGroupCcrn,
+		IssueId:                  issueId,
+		EvidenceId:               eId,
+		ServiceId:                serviceId,
+		ComponentInstanceId:      ciId,
+		Search:                   filter.Search,
+		ComponentCCRN:            filter.ComponentCcrn,
+		PrimaryName:              filter.PrimaryName,
+		IssueType:                lo.Map(filter.IssueType, func(item *model.IssueTypes, _ int) *string { return pointer.String(item.String()) }),
+		ServiceOwnerUsername:     filter.ServiceOwnerUsername,
+		ServiceOwnerUniqueUserId: filter.ServiceOwnerUniqueUserID,
+		State:                    model.GetStateFilterType(filter.State),
 	}
 
 	opt := GetListOptions(requestedFields)

--- a/internal/api/graphql/graph/schema/issue_match.graphqls
+++ b/internal/api/graphql/graph/schema/issue_match.graphqls
@@ -41,6 +41,8 @@ input IssueMatchFilter {
     serviceCcrn: [String]
     supportGroupCcrn: [String]
     state: [StateFilter!]
+    serviceOwnerUsername: [String]
+    serviceOwnerUniqueUserId: [String]
 }
 
 #type CCloudSeverity {

--- a/internal/database/mariadb/issue_match_test.go
+++ b/internal/database/mariadb/issue_match_test.go
@@ -376,6 +376,64 @@ var _ = Describe("IssueMatch", Label("database", "IssueMatch"), func() {
 						})
 					}
 				})
+				It("can filter by a single service owner name that does exist", func() {
+					owner := seedCollection.OwnerRows[rand.Intn(len(seedCollection.OwnerRows))]
+
+					user, _ := lo.Find(seedCollection.UserRows, func(u mariadb.UserRow) bool {
+						return u.Id.Int64 == owner.UserId.Int64
+					})
+
+					ims := seedCollection.GetIssueMatchesByServiceOwner(owner)
+
+					imIds := lo.Map(ims, func(im mariadb.IssueMatchRow, _ int) int64 {
+						return im.Id.Int64
+					})
+
+					filter := &entity.IssueMatchFilter{
+						ServiceOwnerUsername: []*string{&user.Name.String},
+					}
+
+					entries, err := db.GetIssueMatches(filter, nil)
+
+					By("throwing no error", func() {
+						Expect(err).To(BeNil())
+					})
+
+					By("entries contain im", func() {
+						for _, entry := range entries {
+							Expect(lo.Contains(imIds, entry.Id)).To(BeTrue())
+						}
+					})
+				})
+				It("can filter by a single service owner unique user id that does exist", func() {
+					owner := seedCollection.OwnerRows[rand.Intn(len(seedCollection.OwnerRows))]
+
+					user, _ := lo.Find(seedCollection.UserRows, func(u mariadb.UserRow) bool {
+						return u.Id.Int64 == owner.UserId.Int64
+					})
+
+					ims := seedCollection.GetIssueMatchesByServiceOwner(owner)
+
+					imIds := lo.Map(ims, func(im mariadb.IssueMatchRow, _ int) int64 {
+						return im.Id.Int64
+					})
+
+					filter := &entity.IssueMatchFilter{
+						ServiceOwnerUniqueUserId: []*string{&user.UniqueUserID.String},
+					}
+
+					entries, err := db.GetIssueMatches(filter, nil)
+
+					By("throwing no error", func() {
+						Expect(err).To(BeNil())
+					})
+
+					By("entries contain im", func() {
+						for _, entry := range entries {
+							Expect(lo.Contains(imIds, entry.Id)).To(BeTrue())
+						}
+					})
+				})
 				Context("and and we use Pagination", func() {
 					DescribeTable("can correctly paginate ", func(pageSize int) {
 						test.TestPaginationOfListWithOrder(

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -75,6 +75,21 @@ func (s *SeedCollection) GetIssueVariantsByIssueId(id int64) []mariadb.IssueVari
 	return r
 }
 
+func (s *SeedCollection) GetIssueMatchesByServiceOwner(owner mariadb.OwnerRow) []mariadb.IssueMatchRow {
+	serviceIds := lo.FilterMap(s.OwnerRows, func(o mariadb.OwnerRow, _ int) (int64, bool) {
+		return o.ServiceId.Int64, o.UserId.Int64 == owner.UserId.Int64
+	})
+
+	ciIds := lo.FilterMap(s.ComponentInstanceRows, func(c mariadb.ComponentInstanceRow, _ int) (int64, bool) {
+		return c.Id.Int64, lo.Contains(serviceIds, c.ServiceId.Int64)
+	})
+
+	return lo.Filter(s.IssueMatchRows, func(im mariadb.IssueMatchRow, _ int) bool {
+		return lo.Contains(ciIds, im.ComponentInstanceId.Int64)
+
+	})
+}
+
 func (s *SeedCollection) GetIssueVariantsByService(service *mariadb.BaseServiceRow) []mariadb.IssueVariantRow {
 	var issueVariants []mariadb.IssueVariantRow
 	for _, irs := range s.IssueRepositoryServiceRows {

--- a/internal/entity/issue_match.go
+++ b/internal/entity/issue_match.go
@@ -56,20 +56,22 @@ type IssueMatch struct {
 
 type IssueMatchFilter struct {
 	PaginatedX
-	Id                  []*int64          `json:"id"`
-	ServiceCCRN         []*string         `json:"service_ccrn"`
-	SeverityValue       []*string         `json:"severity_value"`
-	Status              []*string         `json:"status"`
-	IssueId             []*int64          `json:"issue_id"`
-	EvidenceId          []*int64          `json:"evidence_id"`
-	ComponentInstanceId []*int64          `json:"component_instance_id"`
-	ServiceId           []*int64          `json:"service_id"`
-	SupportGroupCCRN    []*string         `json:"support_group_ccrn"`
-	Search              []*string         `json:"search"`
-	ComponentCCRN       []*string         `json:"component_ccrn"`
-	PrimaryName         []*string         `json:"primary_name"`
-	IssueType           []*string         `json:"issue_type"`
-	State               []StateFilterType `json:"state"`
+	Id                       []*int64          `json:"id"`
+	ServiceCCRN              []*string         `json:"service_ccrn"`
+	SeverityValue            []*string         `json:"severity_value"`
+	Status                   []*string         `json:"status"`
+	IssueId                  []*int64          `json:"issue_id"`
+	EvidenceId               []*int64          `json:"evidence_id"`
+	ComponentInstanceId      []*int64          `json:"component_instance_id"`
+	ServiceId                []*int64          `json:"service_id"`
+	SupportGroupCCRN         []*string         `json:"support_group_ccrn"`
+	Search                   []*string         `json:"search"`
+	ComponentCCRN            []*string         `json:"component_ccrn"`
+	PrimaryName              []*string         `json:"primary_name"`
+	IssueType                []*string         `json:"issue_type"`
+	State                    []StateFilterType `json:"state"`
+	ServiceOwnerUsername     []*string         `json:"service_owner_username"`
+	ServiceOwnerUniqueUserId []*string         `json:"service_owner_unique_user_id"`
 }
 
 type IssueMatchResult struct {


### PR DESCRIPTION
## Description

Add the possibility to filter `IssueMatch` by ServiceOwner:
- ServiceOwnerUsername
- ServiceOwnerUniqueUserId

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #558 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
