### PR TITLE
fix: missing user reference

### DIFF
--- a/internal/app/issue_match/issue_match_handler_events.go
+++ b/internal/app/issue_match/issue_match_handler_events.go
@@ -189,6 +189,10 @@ func OnComponentVersionAssignmentToComponentInstance(db database.Database, compo
 		// currently a static user is assumed to be used, this going to change in future to either a configured user or a dynamically
 		// infered user from the component version issue macht
 		issue_match := &entity.IssueMatch{
+			Metadata: entity.Metadata{
+				CreatedBy: 1, //@todo discuss whatever we use a static system user or infer the user from the ComponentVersionIssue
+				UpdatedBy: 1, //@todo discuss whatever we use a static system user or infer the user from the ComponentVersionIssue
+			},
 			UserId:                1, //@todo discuss whatever we use a static system user or infer the user from the ComponentVersionIssue
 			Status:                entity.IssueMatchStatusValuesNew,
 			Severity:              issueVariantMap[issueId].Severity, //we got two  simply take the first one


### PR DESCRIPTION
## Description

Fixing missing user reference on the creation of IssueMatches in the OnComponentInstaceAttachedToComponentVersion event. This results in no Issue Matches being created when a k8s scanner is running after the Keppel scanner.

The user is for now static and this needs to be adjusted post MVP


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert