### PR TITLE
fix(cv): add id when severity order is set

### DIFF
--- a/internal/api/graphql/graph/baseResolver/component_version.go
+++ b/internal/api/graphql/graph/baseResolver/component_version.go
@@ -121,6 +121,7 @@ func ComponentVersionBaseResolver(app app.Heureka, ctx context.Context, filter *
 			opt.Order = append(opt.Order, entity.Order{By: entity.MediumCount, Direction: o.Direction.ToOrderDirectionEntity()})
 			opt.Order = append(opt.Order, entity.Order{By: entity.LowCount, Direction: o.Direction.ToOrderDirectionEntity()})
 			opt.Order = append(opt.Order, entity.Order{By: entity.NoneCount, Direction: o.Direction.ToOrderDirectionEntity()})
+			opt.Order = append(opt.Order, entity.Order{By: entity.ComponentVersionId, Direction: o.Direction.ToOrderDirectionEntity()})
 		}
 	}
 

--- a/internal/database/mariadb/cursor.go
+++ b/internal/database/mariadb/cursor.go
@@ -183,12 +183,11 @@ func WithComponentInstance(order []entity.Order, ci entity.ComponentInstance) Ne
 func WithComponentVersion(order []entity.Order, cv entity.ComponentVersion, isc entity.IssueSeverityCounts) NewCursor {
 
 	return func(cursors *cursors) error {
-		var containsId bool
+		order = GetDefaultOrder(order, entity.ComponentVersionId, entity.OrderDirectionAsc)
 		for _, o := range order {
 			switch o.By {
 			case entity.ComponentVersionId:
 				cursors.fields = append(cursors.fields, Field{Name: entity.ComponentVersionId, Value: cv.Id, Order: o.Direction})
-				containsId = true
 			case entity.CriticalCount:
 				cursors.fields = append(cursors.fields, Field{Name: entity.CriticalCount, Value: isc.Critical, Order: o.Direction})
 			case entity.HighCount:
@@ -202,9 +201,6 @@ func WithComponentVersion(order []entity.Order, cv entity.ComponentVersion, isc 
 			default:
 				continue
 			}
-		}
-		if !containsId {
-			cursors.fields = append(cursors.fields, Field{Name: entity.ComponentVersionId, Value: cv.Id, Order: entity.OrderDirectionAsc})
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

When ComponentVersions are ordered by severity, we additionally pass the ComponentVersionId for ordering.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
