### PR TITLE
fix: grouping cronjobs

### DIFF
--- a/scanner/k8s-assets/processor/processor.go
+++ b/scanner/k8s-assets/processor/processor.go
@@ -204,7 +204,7 @@ func (p *Processor) getService(ctx context.Context, serviceInfo scanner.ServiceI
 	return "", fmt.Errorf("ListServices returned no ServiceID")
 }
 
-// CollectUniqueContainers processes a PodReplicaSet and returns a slice of
+// CollectUniqueContainers processes a PodSet and returns a slice of
 // unique container name, image name, and image ID combinations with their
 // respective counts across all pods in the replica set.
 //
@@ -213,17 +213,17 @@ func (p *Processor) getService(ctx context.Context, serviceInfo scanner.ServiceI
 // times each unique combination appears across all pods in the replica set.
 //
 // Parameters:
-//   - podReplicaSet: A scanner.PodReplicaSet object representing a group of related pods.
+//   - podReplicaSet: A scanner.PodSet object representing a group of related pods.
 //
 // Returns:
 //   - []UniqueContainerInfo: A slice of UniqueContainerInfo structs. Each struct contains:
 //   - ContainerInfo: The original container information (Name, Image, ImageHash).
-//   - Count: The number of times this unique combination appears in the PodReplicaSet.
+//   - Count: The number of times this unique combination appears in the PodSet.
 //
 // The returned slice will contain one entry for each unique combination of
-// container name, image name, and image ID found in the PodReplicaSet, along
+// container name, image name, and image ID found in the PodSet, along
 // with a count of its occurrences.
-func (p *Processor) CollectUniqueContainers(podReplicaSet scanner.PodReplicaSet) []UniqueContainerInfo {
+func (p *Processor) CollectUniqueContainers(podReplicaSet scanner.PodSet) []UniqueContainerInfo {
 	uniqueContainers := make(map[string]*UniqueContainerInfo)
 
 	for _, pod := range podReplicaSet.Pods {
@@ -249,7 +249,7 @@ func (p *Processor) CollectUniqueContainers(podReplicaSet scanner.PodReplicaSet)
 	return result
 }
 
-func (p *Processor) ProcessPodReplicaSet(ctx context.Context, namespace string, serviceID string, podReplicaSet scanner.PodReplicaSet) error {
+func (p *Processor) ProcessPodReplicaSet(ctx context.Context, namespace string, serviceID string, podReplicaSet scanner.PodSet) error {
 	uniqueContainers := p.CollectUniqueContainers(podReplicaSet)
 
 	for _, containerInfo := range uniqueContainers {
@@ -272,7 +272,7 @@ func (p *Processor) getComponentInstance(ctx context.Context, ccrn string) (stri
 		return "", fmt.Errorf("Couldn't list ComponentInstances")
 	}
 
-	if listComponentInstancesResp != nil && listComponentInstancesResp.ComponentInstances != nil && listComponentInstancesResp.ComponentInstances.TotalCount > 0 {
+	if listComponentInstancesResp != nil && listComponentInstancesResp.ComponentInstances != nil && len(listComponentInstancesResp.ComponentInstances.Edges) > 0 {
 		return listComponentInstancesResp.ComponentInstances.Edges[0].Node.Id, nil
 	}
 

--- a/scanner/k8s-assets/processor/processor_test.go
+++ b/scanner/k8s-assets/processor/processor_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Processor", func() {
 	Describe("CollectUniqueContainers", func() {
 		Context("with a single pod and single container", func() {
 			It("should return one unique container", func() {
-				podReplicaSet := scanner.PodReplicaSet{
+				podReplicaSet := scanner.PodSet{
 					GenerateName: "test-pod",
 					Pods: []scanner.PodInfo{
 						{
@@ -42,7 +42,7 @@ var _ = Describe("Processor", func() {
 
 		Context("with multiple pods having overlapping containers", func() {
 			It("should return all unique containers", func() {
-				podReplicaSet := scanner.PodReplicaSet{
+				podReplicaSet := scanner.PodSet{
 					GenerateName: "test-pod",
 					Pods: []scanner.PodInfo{
 						{
@@ -80,7 +80,7 @@ var _ = Describe("Processor", func() {
 
 		Context("with multiple pods having different image hashes", func() {
 			It("should return containers with different image hashes and correct counts", func() {
-				podReplicaSet := scanner.PodReplicaSet{
+				podReplicaSet := scanner.PodSet{
 					GenerateName: "test-pod",
 					Pods: []scanner.PodInfo{
 						{
@@ -139,14 +139,14 @@ var _ = Describe("Processor", func() {
 
 		Context("with edge cases", func() {
 			It("should handle empty pods, no containers, and empty replica sets", func() {
-				emptyPodReplicaSet := scanner.PodReplicaSet{
+				emptyPodReplicaSet := scanner.PodSet{
 					GenerateName: "empty-pods",
 					Pods:         []scanner.PodInfo{{}},
 				}
 				result := p.CollectUniqueContainers(emptyPodReplicaSet)
 				Expect(result).To(BeEmpty())
 
-				noContainersPodReplicaSet := scanner.PodReplicaSet{
+				noContainersPodReplicaSet := scanner.PodSet{
 					GenerateName: "no-containers",
 					Pods: []scanner.PodInfo{
 						{Name: "pod1", Containers: []scanner.ContainerInfo{}},
@@ -156,7 +156,7 @@ var _ = Describe("Processor", func() {
 				result = p.CollectUniqueContainers(noContainersPodReplicaSet)
 				Expect(result).To(BeEmpty())
 
-				emptyReplicaSet := scanner.PodReplicaSet{
+				emptyReplicaSet := scanner.PodSet{
 					GenerateName: "empty-replica-set",
 					Pods:         []scanner.PodInfo{},
 				}
@@ -165,7 +165,7 @@ var _ = Describe("Processor", func() {
 			})
 
 			It("should handle containers with empty names or image hashes", func() {
-				podReplicaSet := scanner.PodReplicaSet{
+				podReplicaSet := scanner.PodSet{
 					GenerateName: "empty-fields",
 					Pods: []scanner.PodInfo{
 						{Name: "pod1", Containers: []scanner.ContainerInfo{
@@ -182,7 +182,7 @@ var _ = Describe("Processor", func() {
 
 			It("should handle when all containers across all pods are identical", func() {
 				container := scanner.ContainerInfo{Name: "container", Image: "image", ImageHash: "hash"}
-				podReplicaSet := scanner.PodReplicaSet{
+				podReplicaSet := scanner.PodSet{
 					GenerateName: "all-identical",
 					Pods: []scanner.PodInfo{
 						{Name: "pod1", Containers: []scanner.ContainerInfo{container, container}},


### PR DESCRIPTION
## Description

Groups Jobs below a PodSet and changed naming from PodReplicaSet to  to PodSet to make clear that this includes all kinds of pod sets such as ReplicaSet, StatefullSet, DaemonSet, Job etc. 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
