### PR TITLE
feat(issueCounts): allow filter by support group

### DIFF
--- a/internal/api/graphql/graph/baseResolver/issue.go
+++ b/internal/api/graphql/graph/baseResolver/issue.go
@@ -101,6 +101,7 @@ func IssueBaseResolver(app app.Heureka, ctx context.Context, filter *model.Issue
 	f := &entity.IssueFilter{
 		Paginated:          entity.Paginated{First: first, After: afterId},
 		ServiceCCRN:        filter.ServiceCcrn,
+		SupportGroupCCRN:   filter.SupportGroupCcrn,
 		ActivityId:         activityId,
 		ComponentVersionId: cvId,
 		PrimaryName:        filter.PrimaryName,
@@ -174,6 +175,7 @@ func IssueNameBaseResolver(app app.Heureka, ctx context.Context, filter *model.I
 		Paginated:                       entity.Paginated{},
 		ServiceCCRN:                     filter.ServiceCcrn,
 		PrimaryName:                     filter.PrimaryName,
+		SupportGroupCCRN:                filter.SupportGroupCcrn,
 		Type:                            lo.Map(filter.IssueType, func(item *model.IssueTypes, _ int) *string { return pointer.String(item.String()) }),
 		Search:                          filter.Search,
 		IssueMatchStatus:                nil, //@todo Implement
@@ -240,6 +242,7 @@ func IssueCountsBaseResolver(app app.Heureka, ctx context.Context, filter *model
 	f := &entity.IssueFilter{
 		Paginated:          entity.Paginated{},
 		ServiceCCRN:        filter.ServiceCcrn,
+		SupportGroupCCRN:   filter.SupportGroupCcrn,
 		PrimaryName:        filter.PrimaryName,
 		Type:               lo.Map(filter.IssueType, func(item *model.IssueTypes, _ int) *string { return pointer.String(item.String()) }),
 		Search:             filter.Search,

--- a/internal/api/graphql/graph/queryCollection/issueCounts/query.graphql
+++ b/internal/api/graphql/graph/queryCollection/issueCounts/query.graphql
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+query ($filter: IssueFilter) {
+    IssueCounts (
+        filter: $filter,
+    ) {
+        critical
+        high
+        medium
+        low
+        none
+    }
+}

--- a/internal/api/graphql/graph/resolver/query.go
+++ b/internal/api/graphql/graph/resolver/query.go
@@ -109,6 +109,10 @@ func (r *queryResolver) ScannerRuns(ctx context.Context, filter *model.ScannerRu
 	return baseResolver.ScannerRuns(r.App, ctx, filter, first, after)
 }
 
+func (r *queryResolver) IssueCounts(ctx context.Context, filter *model.IssueFilter) (*model.SeverityCounts, error) {
+	return baseResolver.IssueCountsBaseResolver(r.App, ctx, filter, nil)
+}
+
 func (r *Resolver) Query() graph.QueryResolver { return &queryResolver{r} }
 
 type queryResolver struct{ *Resolver }

--- a/internal/api/graphql/graph/schema/issue.graphqls
+++ b/internal/api/graphql/graph/schema/issue.graphqls
@@ -57,6 +57,7 @@ enum IssueStatusValues {
 
 input IssueFilter {
     serviceCcrn: [String],
+    supportGroupCcrn: [String],
     primaryName: [String],
     issueMatchStatus: [IssueMatchStatusValues],
     issueType: [IssueTypes],

--- a/internal/api/graphql/graph/schema/query.graphqls
+++ b/internal/api/graphql/graph/schema/query.graphqls
@@ -21,4 +21,5 @@ type Query {
     ComponentFilterValues: ComponentFilterValue
     ScannerRunTagFilterValues: [String]
     ScannerRuns(filter: ScannerRunFilter, first: Int, after: String): ScannerRunConnection
+    IssueCounts(filter: IssueFilter): SeverityCounts
 }

--- a/internal/e2e/issue_counts_query_test.go
+++ b/internal/e2e/issue_counts_query_test.go
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+
+	"github.com/cloudoperators/heureka/internal/entity"
+	"github.com/cloudoperators/heureka/internal/util"
+	util2 "github.com/cloudoperators/heureka/pkg/util"
+
+	"github.com/cloudoperators/heureka/internal/server"
+
+	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
+	"github.com/cloudoperators/heureka/internal/database/mariadb"
+	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
+	"github.com/machinebox/graphql"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Getting IssueCounts via API", Label("e2e", "IssueCounts"), func() {
+	var seeder *test.DatabaseSeeder
+	var s *server.Server
+	var cfg util.Config
+
+	BeforeEach(func() {
+		var err error
+		_ = dbm.NewTestSchema()
+		seeder, err = test.NewDatabaseSeeder(dbm.DbConfig())
+		Expect(err).To(BeNil(), "Database Seeder Setup should work")
+
+		cfg = dbm.DbConfig()
+		cfg.Port = util2.GetRandomFreePort()
+		s = server.NewServer(cfg)
+
+		s.NonBlockingStart()
+	})
+
+	AfterEach(func() {
+		s.BlockingStop()
+	})
+
+	When("the database has 100 entries", func() {
+
+		var seedCollection *test.SeedCollection
+		BeforeEach(func() {
+			seedCollection = seeder.SeedDbWithNFakeData(100)
+		})
+		Context("and a filter is used", func() {
+			It("correct filters by support group", func() {
+				sg := seedCollection.SupportGroupRows[rand.Intn(len(seedCollection.SupportGroupRows))]
+				serviceIds := lo.FilterMap(seedCollection.SupportGroupServiceRows, func(sgs mariadb.SupportGroupServiceRow, _ int) (int64, bool) {
+					return sgs.ServiceId.Int64, sg.Id.Int64 == sgs.SupportGroupId.Int64
+				})
+
+				ciIds := lo.FilterMap(seedCollection.ComponentInstanceRows, func(c mariadb.ComponentInstanceRow, _ int) (int64, bool) {
+					return c.Id.Int64, lo.Contains(serviceIds, c.ServiceId.Int64)
+				})
+
+				issueIds := lo.FilterMap(seedCollection.IssueMatchRows, func(im mariadb.IssueMatchRow, _ int) (int64, bool) {
+					return im.IssueId.Int64, lo.Contains(ciIds, im.ComponentInstanceId.Int64)
+				})
+
+				counts := model.SeverityCounts{}
+
+				// avoid counting duplicates
+				ratingIssueIds := map[string]bool{}
+				for _, iv := range seedCollection.IssueVariantRows {
+					key := fmt.Sprintf("%d-%s", iv.IssueId.Int64, iv.Rating.String)
+					if _, ok := ratingIssueIds[key]; ok || !iv.Id.Valid {
+						continue
+					}
+					if lo.Contains(issueIds, iv.IssueId.Int64) {
+						switch iv.Rating.String {
+						case entity.SeverityValuesCritical.String():
+							counts.Critical++
+						case entity.SeverityValuesHigh.String():
+							counts.High++
+						case entity.SeverityValuesMedium.String():
+							counts.Medium++
+						case entity.SeverityValuesLow.String():
+							counts.Low++
+						case entity.SeverityValuesNone.String():
+							counts.None++
+						}
+					}
+					ratingIssueIds[key] = true
+				}
+
+				// create a queryCollection (safe to share across requests)
+				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
+
+				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
+				b, err := os.ReadFile("../api/graphql/graph/queryCollection/service/withIssueCounts.graphql")
+
+				Expect(err).To(BeNil())
+				str := string(b)
+				req := graphql.NewRequest(str)
+				req.Var("filter", map[string]string{
+					"supportGroupCcrn": sg.CCRN.String,
+				})
+
+				req.Header.Set("Cache-Control", "no-cache")
+				ctx := context.Background()
+
+				var respData struct {
+					IssueCounts model.SeverityCounts `json:"IssueCounts"`
+				}
+				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
+					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
+				}
+
+				Expect(respData.IssueCounts.Critical).To(Equal(counts.Critical))
+				Expect(respData.IssueCounts.High).To(Equal(counts.High))
+				Expect(respData.IssueCounts.Medium).To(Equal(counts.Medium))
+				Expect(respData.IssueCounts.Low).To(Equal(counts.Low))
+				Expect(respData.IssueCounts.None).To(Equal(counts.None))
+			})
+		})
+	})
+})

--- a/internal/entity/issue.go
+++ b/internal/entity/issue.go
@@ -53,6 +53,7 @@ type IssueFilter struct {
 	Paginated
 	PrimaryName                     []*string         `json:"primary_name"`
 	ServiceCCRN                     []*string         `json:"service_ccrn"`
+	SupportGroupCCRN                []*string         `json:"support_group_ccrn"`
 	Type                            []*string         `json:"type"`
 	Id                              []*int64          `json:"id"`
 	ActivityId                      []*int64          `json:"activity_id"`


### PR DESCRIPTION
## Description

Add `isseCounts` query and add `SupportGroupCcrn` to `IssueFilter`. This enables filtering `issueCounts` by severity for a Support Group (i.e. for all services that belong to a Support Group).

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #592 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
