### PR TITLE
feat(issueCounts): allow easy filter by all services

### DIFF
--- a/internal/api/graphql/graph/baseResolver/issue.go
+++ b/internal/api/graphql/graph/baseResolver/issue.go
@@ -247,7 +247,7 @@ func IssueCountsBaseResolver(app app.Heureka, ctx context.Context, filter *model
 		ComponentVersionId: cvId,
 		ServiceId:          serviceId,
 		State:              model.GetStateFilterType(filter.State),
-		AllServices:        filter.AllServices,
+		AllServices:        lo.FromPtr(filter.AllServices),
 	}
 
 	counts, err := app.GetIssueSeverityCounts(f)

--- a/internal/api/graphql/graph/baseResolver/issue.go
+++ b/internal/api/graphql/graph/baseResolver/issue.go
@@ -247,6 +247,7 @@ func IssueCountsBaseResolver(app app.Heureka, ctx context.Context, filter *model
 		ComponentVersionId: cvId,
 		ServiceId:          serviceId,
 		State:              model.GetStateFilterType(filter.State),
+		AllServices:        filter.AllServices,
 	}
 
 	counts, err := app.GetIssueSeverityCounts(f)

--- a/internal/api/graphql/graph/baseResolver/service.go
+++ b/internal/api/graphql/graph/baseResolver/service.go
@@ -144,7 +144,7 @@ func ServiceBaseResolver(app app.Heureka, ctx context.Context, filter *model.Ser
 
 	if lo.Contains(requestedFields, "issueCounts") {
 		icFilter := &model.IssueFilter{
-			AllServices: true,
+			AllServices: lo.ToPtr(true),
 		}
 		severityCounts, err := IssueCountsBaseResolver(app, ctx, icFilter, nil)
 		if err != nil {

--- a/internal/api/graphql/graph/baseResolver/service.go
+++ b/internal/api/graphql/graph/baseResolver/service.go
@@ -142,6 +142,17 @@ func ServiceBaseResolver(app app.Heureka, ctx context.Context, filter *model.Ser
 		PageInfo:   model.NewPageInfo(services.PageInfo),
 	}
 
+	if lo.Contains(requestedFields, "issueCounts") {
+		icFilter := &model.IssueFilter{
+			AllServices: true,
+		}
+		severityCounts, err := IssueCountsBaseResolver(app, ctx, icFilter, nil)
+		if err != nil {
+			return nil, NewResolverError("ServiceBaseResolver", err.Error())
+		}
+		connection.IssueCounts = severityCounts
+	}
+
 	return &connection, nil
 
 }

--- a/internal/api/graphql/graph/schema/issue.graphqls
+++ b/internal/api/graphql/graph/schema/issue.graphqls
@@ -67,7 +67,7 @@ input IssueFilter {
     componentVersionId: [String],
 
     search: [String],
-    allServices: Boolean!,
+    allServices: Boolean,
 
     # leave away for MVP
     # cveDescription: [String]

--- a/internal/api/graphql/graph/schema/issue.graphqls
+++ b/internal/api/graphql/graph/schema/issue.graphqls
@@ -67,6 +67,7 @@ input IssueFilter {
     componentVersionId: [String],
 
     search: [String],
+    allServices: Boolean!,
 
     # leave away for MVP
     # cveDescription: [String]

--- a/internal/api/graphql/graph/schema/service.graphqls
+++ b/internal/api/graphql/graph/schema/service.graphqls
@@ -27,6 +27,7 @@ input ServiceInput {
 
 type ServiceConnection implements Connection {
     totalCount: Int!
+    issueCounts: SeverityCounts
     edges: [ServiceEdge]
     pageInfo: PageInfo
 }

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -114,6 +114,12 @@ func (s *SqlDatabase) getIssueJoins(filter *entity.IssueFilter, order []entity.O
 		`)
 	}
 
+	if filter.AllServices {
+		joins = fmt.Sprintf("%s\n%s", joins, `
+			RIGHT JOIN IssueMatch IM ON I.issue_id = IM.issuematch_issue_id
+		`)
+	}
+
 	return joins
 }
 

--- a/internal/entity/issue.go
+++ b/internal/entity/issue.go
@@ -53,6 +53,7 @@ type IssueFilter struct {
 	PaginatedX
 	PrimaryName                     []*string         `json:"primary_name"`
 	ServiceCCRN                     []*string         `json:"service_ccrn"`
+	AllServices                     bool              `json:"all_services"`
 	SupportGroupCCRN                []*string         `json:"support_group_ccrn"`
 	Type                            []*string         `json:"type"`
 	Id                              []*int64          `json:"id"`


### PR DESCRIPTION
## Description

Add `issueCounts` to the `ServiceConnection` that allows to fetch issueCounts for all Services.

Example query:

```graphql

{
  Services{
    issueCounts{
      critical
      high
      medium
      low
      none
    }
    edges{
      node{
        ccrn
      }
    }
  }
}
```
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #600
