### PR TITLE
feat(service): Assign supportgroup to unknown service

### DIFF
--- a/scanner/k8s-assets/processor/processor.go
+++ b/scanner/k8s-assets/processor/processor.go
@@ -107,7 +107,7 @@ func (p *Processor) ProcessService(ctx context.Context, serviceInfo scanner.Serv
 	var serviceId string
 
 	if serviceInfo.CCRN == "" {
-		serviceInfo.CCRN = "none"
+		serviceInfo.CCRN = fmt.Sprintf("Unknown-%s", serviceInfo.SupportGroup)
 	}
 
 	// The Service might already exist in the DB


### PR DESCRIPTION
The k8s-assets scanner is reading owner
information from the owner-helm-chart.
The supportGroup attribute is mandatory, but
the service attribute is optional.
Currently, if the scanner encounters such a case,
it adds the componentInstance to a None service.
This will lead to one none service, that has
componentInstances assigned from multiple
supportGroup including all their vulnerabilities.

Instead of a single 'none` service for all Support Groups, we want to have one per Support Group.
The name for this will be "Unknown-{SupportGroupName}"

## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)

> Remove if not applicable

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [ ] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
