### PR TITLE
feat(issueCounts): align issueCounts

### DIFF
--- a/internal/api/graphql/graph/baseResolver/service.go
+++ b/internal/api/graphql/graph/baseResolver/service.go
@@ -150,7 +150,12 @@ func ServiceBaseResolver(app app.Heureka, ctx context.Context, filter *model.Ser
 
 	if lo.Contains(requestedFields, "issueCounts") {
 		icFilter := &model.IssueFilter{
-			AllServices: lo.ToPtr(true),
+			SupportGroupCcrn: filter.SupportGroupCcrn,
+		}
+		if f.CCRN != nil {
+			icFilter.ServiceCcrn = f.CCRN
+		} else {
+			icFilter.AllServices = lo.ToPtr(true)
 		}
 		severityCounts, err := IssueCountsBaseResolver(app, ctx, icFilter, nil)
 		if err != nil {

--- a/internal/api/graphql/graph/model/models.go
+++ b/internal/api/graphql/graph/model/models.go
@@ -253,6 +253,7 @@ func NewSeverityCounts(counts *entity.IssueSeverityCounts) SeverityCounts {
 		Medium:   int(counts.Medium),
 		Low:      int(counts.Low),
 		None:     int(counts.None),
+		Total:    int(counts.Total),
 	}
 }
 

--- a/internal/api/graphql/graph/queryCollection/componentVersion/withIssueCounts.graphql
+++ b/internal/api/graphql/graph/queryCollection/componentVersion/withIssueCounts.graphql
@@ -17,6 +17,7 @@ query ($filter: ComponentVersionFilter, $first: Int, $after: String) {
                     medium
                     low
                     none
+                    total
                 }
             }
         }

--- a/internal/api/graphql/graph/queryCollection/issueCounts/query.graphql
+++ b/internal/api/graphql/graph/queryCollection/issueCounts/query.graphql
@@ -10,5 +10,6 @@ query ($filter: IssueFilter) {
         medium
         low
         none
+        total
     }
 }

--- a/internal/api/graphql/graph/queryCollection/service/withIssueCounts.graphql
+++ b/internal/api/graphql/graph/queryCollection/service/withIssueCounts.graphql
@@ -14,6 +14,7 @@ query {
                     medium
                     low
                     none
+                    total
                 }
             }
         }

--- a/internal/api/graphql/graph/schema/common.graphqls
+++ b/internal/api/graphql/graph/schema/common.graphqls
@@ -47,6 +47,7 @@ type SeverityCounts {
     medium: Int!
     low: Int!
     none: Int!
+    total: Int!
 }
 
 input DateTimeFilter {

--- a/internal/database/mariadb/entity.go
+++ b/internal/database/mariadb/entity.go
@@ -132,13 +132,15 @@ type RatingCount struct {
 }
 
 func (rc *RatingCount) AsIssueSeverityCounts() entity.IssueSeverityCounts {
-	return entity.IssueSeverityCounts{
+	isc := entity.IssueSeverityCounts{
 		Critical: GetInt64Value(rc.Critical),
 		High:     GetInt64Value(rc.High),
 		Medium:   GetInt64Value(rc.Medium),
 		Low:      GetInt64Value(rc.Low),
 		None:     GetInt64Value(rc.None),
 	}
+	isc.Total = isc.Critical + isc.High + isc.Medium + isc.Low + isc.None
+	return isc
 }
 
 type IssueRow struct {

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -442,12 +442,25 @@ func (s *SqlDatabase) CountIssueRatings(filter *entity.IssueFilter) (*entity.Iss
 	filter = s.ensureIssueFilter(filter)
 
 	baseQuery := `
-		SELECT IV.issuevariant_rating AS issue_value, COUNT(distinct IV.issuevariant_issue_id) AS issue_count FROM %s Issue I
+		SELECT IV.issuevariant_rating AS issue_value, %s AS issue_count FROM %s Issue I
 		%s
 		%s
 		%s
 		GROUP BY IV.issuevariant_rating ORDER BY %s
 	`
+
+	var countColumn string
+	if filter.AllServices {
+		// Count issues that appear in multiple services and in multiple component versions per service
+		countColumn = "COUNT(distinct CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id, ',', S.service_id))"
+	} else if len(filter.ServiceCCRN) > 0 || len(filter.ServiceId) > 0 {
+		// Count issues that appear in multiple component versions
+		countColumn = "COUNT(distinct CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id))"
+	} else {
+		countColumn = "COUNT(distinct IV.issuevariant_issue_id)"
+	}
+
+	baseQuery = fmt.Sprintf(baseQuery, countColumn, "%s", "%s", "%s", "%s", "%s")
 
 	if len(filter.IssueRepositoryId) == 0 {
 		baseQuery = fmt.Sprintf(baseQuery, "%s", "LEFT JOIN IssueVariant IV ON IV.issuevariant_issue_id = I.issue_id", "%s", "%s", "%s")

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -488,6 +488,7 @@ func (s *SqlDatabase) CountIssueRatings(filter *entity.IssueFilter) (*entity.Iss
 		case entity.SeverityValuesNone.String():
 			issueSeverityCounts.None = count.Count
 		}
+		issueSeverityCounts.Total += count.Count
 	}
 
 	return &issueSeverityCounts, nil

--- a/internal/database/mariadb/issue_test.go
+++ b/internal/database/mariadb/issue_test.go
@@ -547,6 +547,7 @@ var _ = Describe("Issue", Label("database", "Issue"), func() {
 				Expect(issueSeverityCounts.Medium).To(BeEquivalentTo(counts.Medium))
 				Expect(issueSeverityCounts.Low).To(BeEquivalentTo(counts.Low))
 				Expect(issueSeverityCounts.None).To(BeEquivalentTo(counts.None))
+				Expect(issueSeverityCounts.Total).To(BeEquivalentTo(counts.Total))
 			})
 		}
 		Context("and using no filter", func() {
@@ -630,6 +631,7 @@ var _ = Describe("Issue", Label("database", "Issue"), func() {
 					case entity.SeverityValuesNone.String():
 						counts.None++
 					}
+					counts.Total++
 					issueIds[key] = true
 				}
 
@@ -740,6 +742,7 @@ var _ = Describe("Issue", Label("database", "Issue"), func() {
 						case entity.SeverityValuesNone.String():
 							counts.None++
 						}
+						counts.Total++
 					}
 					issueIds[key] = true
 				}
@@ -781,6 +784,7 @@ var _ = Describe("Issue", Label("database", "Issue"), func() {
 						case entity.SeverityValuesNone.String():
 							counts.None++
 						}
+						counts.Total++
 					}
 					ratingIssueIds[key] = true
 				}
@@ -824,6 +828,7 @@ var _ = Describe("Issue", Label("database", "Issue"), func() {
 						case entity.SeverityValuesNone.String():
 							counts.None++
 						}
+						counts.Total++
 					}
 					ratingIssueIds[key] = true
 				}

--- a/internal/database/mariadb/service.go
+++ b/internal/database/mariadb/service.go
@@ -117,15 +117,15 @@ func (s *SqlDatabase) getServiceColumns(filter *entity.ServiceFilter, order []en
 	for _, o := range order {
 		switch o.By {
 		case entity.CriticalCount:
-			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Critical' THEN IV.issuevariant_issue_id END) as critical_count", columns)
+			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Critical' THEN CONCAT(CV.componentversion_id, ',', IV.issuevariant_issue_id) END) as critical_count", columns)
 		case entity.HighCount:
-			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'High' THEN IV.issuevariant_issue_id END) as high_count", columns)
+			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'High' THEN CONCAT(CV.componentversion_id, ',', IV.issuevariant_issue_id) END) as high_count", columns)
 		case entity.MediumCount:
-			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Medium' THEN IV.issuevariant_issue_id END) as medium_count", columns)
+			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Medium' THEN CONCAT(CV.componentversion_id, ',', IV.issuevariant_issue_id) END) as medium_count", columns)
 		case entity.LowCount:
-			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Low' THEN IV.issuevariant_issue_id END) as low_count", columns)
+			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'Low' THEN CONCAT(CV.componentversion_id, ',', IV.issuevariant_issue_id) END) as low_count", columns)
 		case entity.NoneCount:
-			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'None' THEN IV.issuevariant_issue_id END) as none_count", columns)
+			columns = fmt.Sprintf("%s, COUNT(distinct CASE WHEN IV.issuevariant_rating = 'None' THEN CONCAT(CV.componentversion_id, ',', IV.issuevariant_issue_id) END) as none_count", columns)
 		}
 	}
 	return columns

--- a/internal/database/mariadb/test/common.go
+++ b/internal/database/mariadb/test/common.go
@@ -6,6 +6,7 @@ package test
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -257,4 +258,37 @@ func LoadComponentVersionIssues(filename string) ([]mariadb.ComponentVersionIssu
 		}
 	}
 	return componentVersionIssues, nil
+}
+
+func LoadServiceIssueCounts(filename string) (map[string]entity.IssueSeverityCounts, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	type tempIssueCount struct {
+		Critical  int64 `json:"critical"`
+		High      int64 `json:"high"`
+		Medium    int64 `json:"medium"`
+		Low       int64 `json:"low"`
+		None      int64 `json:"none"`
+		Total     int64 `json:"total"`
+		ServiceId int64 `json:"service_id"`
+	}
+	var tempIssueCounts []tempIssueCount
+	if err := json.Unmarshal(data, &tempIssueCounts); err != nil {
+		return nil, err
+	}
+	issueCounts := make(map[string]entity.IssueSeverityCounts, len(tempIssueCounts))
+	for _, tic := range tempIssueCounts {
+		serviceId := fmt.Sprintf("%d", tic.ServiceId)
+		issueCounts[serviceId] = entity.IssueSeverityCounts{
+			Critical: tic.Critical,
+			High:     tic.High,
+			Medium:   tic.Medium,
+			Low:      tic.Low,
+			None:     tic.None,
+			Total:    tic.Total,
+		}
+	}
+	return issueCounts, nil
 }

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -1278,6 +1278,9 @@ func NewFakeIssueVariant(repos []mariadb.BaseIssueRepositoryRow, disc []mariadb.
 	v := GenerateRandomCVSS31Vector()
 	cvss, _ := metric.NewEnvironmental().Decode(v)
 	rating := cvss.Severity().String()
+	if rating == "" {
+		rating = "None"
+	}
 	externalUrl := gofakeit.URL()
 	return mariadb.IssueVariantRow{
 		SecondaryName: sql.NullString{String: fmt.Sprintf("%s-%d-%d", gofakeit.RandomString(variants), gofakeit.Year(), gofakeit.Number(1000, 9999)), Valid: true},

--- a/internal/database/mariadb/testdata/service_order/issue_counts.json
+++ b/internal/database/mariadb/testdata/service_order/issue_counts.json
@@ -1,0 +1,47 @@
+[
+    {
+        "critical": 1,
+        "high": 0,
+        "medium": 0,
+        "low": 1,
+        "none": 0,
+        "total": 2,
+        "service_id": 1
+    },
+    {
+        "critical": 0,
+        "high": 0,
+        "medium": 1,
+        "low": 1,
+        "none": 0,
+        "total": 2,
+        "service_id": 2
+    },
+    {
+        "critical": 1,
+        "high": 0,
+        "medium": 0,
+        "low": 0,
+        "none": 1,
+        "total": 2,
+        "service_id": 3
+    },
+    {
+        "critical": 0,
+        "high": 1,
+        "medium": 1,
+        "low": 0,
+        "none": 0,
+        "total": 2,
+        "service_id": 4
+    },
+    {
+        "critical": 0,
+        "high": 1,
+        "medium": 0,
+        "low": 0,
+        "none": 1,
+        "total": 2,
+        "service_id": 5
+    }
+]

--- a/internal/database/mariadb/testdata/service_order/issue_match.json
+++ b/internal/database/mariadb/testdata/service_order/issue_match.json
@@ -1,0 +1,72 @@
+[
+    {
+        "issue_id": 1,
+        "component_instance_id": 1,
+        "user_id": 1,
+        "rating": "Critical",
+        "status": "Open"
+    },
+    {
+        "issue_id": 7,
+        "component_instance_id": 2,
+        "user_id": 1,
+        "rating": "Low",
+        "status": "Open"
+    },
+    {
+        "issue_id": 5,
+        "component_instance_id": 3,
+        "user_id": 1,
+        "rating": "Medium",
+        "status": "Open"
+    },
+    {
+        "issue_id": 8,
+        "component_instance_id": 4,
+        "user_id": 1,
+        "rating": "Low",
+        "status": "Open"
+    },
+    {
+        "issue_id": 2,
+        "component_instance_id": 5,
+        "user_id": 1,
+        "rating": "Critical",
+        "status": "Open"
+    },
+    {
+        "issue_id": 9,
+        "component_instance_id": 6,
+        "user_id": 1,
+        "rating": "None",
+        "status": "Open"
+    },
+    {
+        "issue_id": 3,
+        "component_instance_id": 7,
+        "user_id": 1,
+        "rating": "High",
+        "status": "Open"
+    },
+    {
+        "issue_id": 6,
+        "component_instance_id": 8,
+        "user_id": 1,
+        "rating": "Medium",
+        "status": "Open"
+    },
+    {
+        "issue_id": 4,
+        "component_instance_id": 9,
+        "user_id": 1,
+        "rating": "High",
+        "status": "Open"
+    },
+    {
+        "issue_id": 10,
+        "component_instance_id": 10,
+        "user_id": 1,
+        "rating": "None",
+        "status": "Open"
+    }
+]

--- a/internal/e2e/component_version_query_test.go
+++ b/internal/e2e/component_version_query_test.go
@@ -244,6 +244,7 @@ var _ = Describe("Getting ComponentVersions via API", Label("e2e", "ComponentVer
 									case "None":
 										counts.None++
 									}
+									counts.Total++
 									issueIds[key] = true
 								}
 							}
@@ -281,6 +282,7 @@ var _ = Describe("Getting ComponentVersions via API", Label("e2e", "ComponentVer
 					Expect(cvEdge.Node.IssueCounts.Medium).To(Equal(sc.Medium))
 					Expect(cvEdge.Node.IssueCounts.Low).To(Equal(sc.Low))
 					Expect(cvEdge.Node.IssueCounts.None).To(Equal(sc.None))
+					Expect(cvEdge.Node.IssueCounts.Total).To(Equal(sc.Total))
 				}
 			})
 		})

--- a/internal/e2e/issue_counts_query_test.go
+++ b/internal/e2e/issue_counts_query_test.go
@@ -91,6 +91,7 @@ var _ = Describe("Getting IssueCounts via API", Label("e2e", "IssueCounts"), fun
 				case "None":
 					severityCounts.None++
 				}
+				severityCounts.Total++
 				issueIds[key] = true
 			}
 			for _, im := range issueMatches {
@@ -136,6 +137,7 @@ var _ = Describe("Getting IssueCounts via API", Label("e2e", "IssueCounts"), fun
 				Expect(respData.IssueCounts.Medium).To(Equal(severityCounts.Medium))
 				Expect(respData.IssueCounts.Low).To(Equal(severityCounts.Low))
 				Expect(respData.IssueCounts.None).To(Equal(severityCounts.None))
+				Expect(respData.IssueCounts.Total).To(Equal(severityCounts.Total))
 			})
 		})
 	})

--- a/internal/e2e/service_query_test.go
+++ b/internal/e2e/service_query_test.go
@@ -353,6 +353,7 @@ var _ = Describe("Getting Services via API", Label("e2e", "Services"), func() {
 							case entity.SeverityValuesNone.String():
 								counts.None++
 							}
+							counts.Total++
 						}
 						ratingIssueIds[key] = true
 					}
@@ -386,6 +387,7 @@ var _ = Describe("Getting Services via API", Label("e2e", "Services"), func() {
 					Expect(sEdge.Node.IssueCounts.Medium).To(Equal(sc.Medium))
 					Expect(sEdge.Node.IssueCounts.Low).To(Equal(sc.Low))
 					Expect(sEdge.Node.IssueCounts.None).To(Equal(sc.None))
+					Expect(sEdge.Node.IssueCounts.Total).To(Equal(sc.Total))
 				}
 			})
 		})

--- a/internal/entity/issue.go
+++ b/internal/entity/issue.go
@@ -109,6 +109,7 @@ type IssueSeverityCounts struct {
 	Medium   int64 `json:"medium"`
 	Low      int64 `json:"low"`
 	None     int64 `json:"none"`
+	Total    int64 `json:"total"`
 }
 
 func (itc *IssueTypeCounts) TotalIssueCount() int64 {


### PR DESCRIPTION
## Description

Align `issueCounts` between different Views by counting 'duplicated' issues that appears in multiple images. For example if cve-123 is present in all 3 images, that would lead to it being counted 3 times.

Additionally, add `total` to the counts.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #639 
- Closes #640 
- Closes #641 

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
