### PR TITLE
fix(k8s-scanner): add cluster to tag name

### DIFF
--- a/scanner/k8s-assets/main.go
+++ b/scanner/k8s-assets/main.go
@@ -194,7 +194,8 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("Error while reading env config")
 	}
-	processor := processor.NewProcessor(cfg, "k8s-assets")
+	tag := fmt.Sprintf("k8s-assets-%s", cfg.ClusterName)
+	processor := processor.NewProcessor(cfg, tag)
 	processor.CreateScannerRun(context.Background())
 
 	// Create context with timeout (30min should be ok)


### PR DESCRIPTION
## Description

Add `cluster` name to the `k8s-scanner` tag to identify the scanner run.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Fixes #685 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
