### PR TITLE
fix(vulnerability): return targetRemediationDate in resolver

### DIFF
--- a/internal/api/graphql/graph/resolver/vulnerability.go
+++ b/internal/api/graphql/graph/resolver/vulnerability.go
@@ -79,7 +79,7 @@ func (r *vulnerabilityResolver) EarliestTargetRemediationDate(ctx context.Contex
 		return nil, nil // No issue match found
 	}
 
-	return im.Edges[0].Node.RemediationDate, nil
+	return im.Edges[0].Node.TargetRemediationDate, nil
 }
 
 func (r *vulnerabilityResolver) Services(ctx context.Context, obj *model.Vulnerability, first *int, after *string) (*model.ServiceConnection, error) {


### PR DESCRIPTION
## Description

The wrong date was returned. Now it returns the `TargetRemediationDate`.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Closes #765 

