### PR TITLE
feat(issueMatch): Added ComponentInstanceId to IssueMatchFilter in GraphQL API

### DIFF
--- a/internal/api/graphql/graph/baseResolver/issue_match.go
+++ b/internal/api/graphql/graph/baseResolver/issue_match.go
@@ -99,6 +99,18 @@ func IssueMatchBaseResolver(app app.Heureka, ctx context.Context, filter *model.
 		issue_match_ids = append(issue_match_ids, filterById)
 	}
 
+	if filter.ComponentInstanceID != nil {
+		ciId = []*int64{}
+		for _, componentInstanceId := range filter.ComponentInstanceID {
+			filterById, err := ParseCursor(componentInstanceId)
+			if err != nil {
+				logrus.WithField("filter", filter).Error("IssueMatchBaseResolver: Error while parsing filter value 'componentInstanceId'")
+				return nil, NewResolverError("IssueMatchBaseResolver", "Bad Request - unable to parse filter, the value of the filter ComponentInstanceId is invalid")
+			}
+			ciId = append(ciId, filterById)
+		}
+	}
+
 	f := &entity.IssueMatchFilter{
 		Id:                       issue_match_ids,
 		PaginatedX:               entity.PaginatedX{First: first, After: after},

--- a/internal/api/graphql/graph/schema/issue_match.graphqls
+++ b/internal/api/graphql/graph/schema/issue_match.graphqls
@@ -35,6 +35,7 @@ input IssueMatchFilter {
     search: [String]
     primaryName: [String]
     componentCcrn: [String]
+    componentInstanceId: [String]
     issueType: [IssueTypes]
     status: [IssueMatchStatusValues]
     severity: [SeverityValues]


### PR DESCRIPTION
## Description
<!--
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

The CSC scanner requires the ability to search issue matches by issue id + component instance id so that it can check for existing issue matches before directly creating a new one for non-compliant findings. Because many resources scanned by the CSC scanner do not have components / component versions, using the existing componentCcrn field in the filter would not work. 

Since filtering by componentInstanceId was already implemented at the app/db layer, this change just adds ComponentInstanceId as a field to the IssueMatchFilter in the GraphQL schema and adds logic to ensure it gets set properly in the filter object that gets passed down to the db layer. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Closes Issue #825 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
