### PR TITLE
refactor(serviceFilter): remove ccrn suffix

### DIFF
--- a/internal/api/graphql/gqlgen.yml
+++ b/internal/api/graphql/gqlgen.yml
@@ -244,7 +244,7 @@ models:
         resolver: true
   ServiceFilterValue:
     fields:
-      serviceCcrn:
+      service:
         resolver: true
       domain:
         resolver: true
@@ -254,7 +254,7 @@ models:
         resolver: true
       userName:
         resolver: true
-      supportGroupCcrn:
+      supportGroup:
         resolver: true
       user:
         resolver: true

--- a/internal/api/graphql/graph/queryCollection/serviceFilter/service.graphql
+++ b/internal/api/graphql/graph/queryCollection/serviceFilter/service.graphql
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-query($filter: SupportGroupFilter){
+query($filter: ServiceFilter){
     ServiceFilterValues{
-        supportGroupCcrn(filter: $filter){
+        service(filter: $filter){
             filterName
             values
         }

--- a/internal/api/graphql/graph/queryCollection/serviceFilter/supportGroup.graphql
+++ b/internal/api/graphql/graph/queryCollection/serviceFilter/supportGroup.graphql
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-query($filter: ServiceFilter){
+query($filter: SupportGroupFilter){
     ServiceFilterValues{
-        serviceCcrn(filter: $filter){
+        supportGroup(filter: $filter){
             filterName
             values
         }

--- a/internal/api/graphql/graph/resolver/service_filter.go
+++ b/internal/api/graphql/graph/resolver/service_filter.go
@@ -15,7 +15,7 @@ import (
 // SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
 // SPDX-License-Identifier: Apache-2.0
 
-func (r *serviceFilterValueResolver) ServiceCcrn(ctx context.Context, obj *model.ServiceFilterValue, filter *model.ServiceFilter) (*model.FilterItem, error) {
+func (r *serviceFilterValueResolver) Service(ctx context.Context, obj *model.ServiceFilterValue, filter *model.ServiceFilter) (*model.FilterItem, error) {
 	item, err := baseResolver.ServiceCcrnBaseResolver(r.App, ctx, filter)
 
 	if err != nil {
@@ -63,9 +63,8 @@ func (r *serviceFilterValueResolver) UserName(ctx context.Context, obj *model.Se
 	return item, err
 }
 
-func (r *serviceFilterValueResolver) SupportGroupCcrn(ctx context.Context, obj *model.ServiceFilterValue, filter *model.SupportGroupFilter) (*model.FilterItem, error) {
+func (r *serviceFilterValueResolver) SupportGroup(ctx context.Context, obj *model.ServiceFilterValue, filter *model.SupportGroupFilter) (*model.FilterItem, error) {
 	item, err := baseResolver.SupportGroupCcrnBaseResolver(r.App, ctx, filter)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/graphql/graph/schema/service_filter.graphqls
+++ b/internal/api/graphql/graph/schema/service_filter.graphqls
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type ServiceFilterValue {
-    serviceCcrn(filter: ServiceFilter): FilterItem
+    service(filter: ServiceFilter): FilterItem
     domain(filter: ServiceFilter): FilterItem
     region(filter: ServiceFilter): FilterItem
     uniqueUserId(filter: UserFilter): FilterItem
     userName(filter: UserFilter): FilterItem
-    supportGroupCcrn(filter: SupportGroupFilter): FilterItem
+    supportGroup(filter: SupportGroupFilter): FilterItem
     user(filter: UserFilter): FilterValueItem
 }

--- a/internal/e2e/service_filter_query_test.go
+++ b/internal/e2e/service_filter_query_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
-	"github.com/cloudoperators/heureka/internal/e2e/common"
+	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -54,7 +54,7 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
 
 			//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql")
+			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/service.graphql")
 
 			Expect(err).To(BeNil())
 			str := string(b)
@@ -70,12 +70,12 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
 			}
 
-			Expect(respData.ServiceFilterValues.ServiceCcrn.Values).To(BeEmpty())
+			Expect(respData.ServiceFilterValues.Service.Values).To(BeEmpty())
 		})
-		It("returns empty for supportGroupCcrns", func() {
+		It("returns empty for supportGroups", func() {
 			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
 
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql")
+			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroup.graphql")
 
 			Expect(err).To(BeNil())
 			str := string(b)
@@ -91,7 +91,7 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
 			}
 
-			Expect(respData.ServiceFilterValues.SupportGroupCcrn.Values).To(BeEmpty())
+			Expect(respData.ServiceFilterValues.SupportGroup.Values).To(BeEmpty())
 		})
 		It("returns empty for userNames", func() {
 			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
@@ -144,10 +144,10 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 			seedCollection = seeder.SeedDbWithNFakeData(10)
 		})
 		Context("and no additional filters are present", func() {
-			It("returns correct serviceCcrns", func() {
+			It("returns correct services", func() {
 				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
 
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql")
+				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/service.graphql")
 
 				Expect(err).To(BeNil())
 				str := string(b)
@@ -163,20 +163,20 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
 				}
 
-				Expect(len(respData.ServiceFilterValues.ServiceCcrn.Values)).To(Equal(len(seedCollection.ServiceRows)))
+				Expect(len(respData.ServiceFilterValues.Service.Values)).To(Equal(len(seedCollection.ServiceRows)))
 
 				existingServiceCcrns := lo.Map(seedCollection.ServiceRows, func(s mariadb.BaseServiceRow, index int) string {
 					return s.CCRN.String
 				})
 
-				for _, ccrn := range respData.ServiceFilterValues.ServiceCcrn.Values {
+				for _, ccrn := range respData.ServiceFilterValues.Service.Values {
 					Expect(lo.Contains(existingServiceCcrns, *ccrn)).To(BeTrue())
 				}
 			})
-			It("returns correct supportGroupCcrns", func() {
+			It("returns correct supportGroups", func() {
 				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
 
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql")
+				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroup.graphql")
 
 				Expect(err).To(BeNil())
 				str := string(b)
@@ -192,13 +192,13 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
 				}
 
-				Expect(len(respData.ServiceFilterValues.SupportGroupCcrn.Values)).To(Equal(len(seedCollection.SupportGroupRows)))
+				Expect(len(respData.ServiceFilterValues.SupportGroup.Values)).To(Equal(len(seedCollection.SupportGroupRows)))
 
 				existingsupportGroupCcrns := lo.Map(seedCollection.SupportGroupRows, func(s mariadb.SupportGroupRow, index int) string {
 					return s.CCRN.String
 				})
 
-				for _, ccrn := range respData.ServiceFilterValues.SupportGroupCcrn.Values {
+				for _, ccrn := range respData.ServiceFilterValues.SupportGroup.Values {
 					Expect(lo.Contains(existingsupportGroupCcrns, *ccrn)).To(BeTrue())
 				}
 			})


### PR DESCRIPTION
## Description

In order to align with the `VulnerabilityFilterValue` the following renaming has been applied:

- serviceCcrn -> service
- supportGroupCcrn -> supportGroup

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
