### PR TITLE
chore(graphql-inspector): add github-app-token

### DIFF
--- a/internal/api/graphql/graph/schema/activity.graphqls
+++ b/internal/api/graphql/graph/schema/activity.graphqls
@@ -28,7 +28,7 @@ type ActivityEdge implements Edge {
 }
 
 input ActivityFilter {
-    service: [String]
+    serviceCcrn: [String]
     status: [ActivityStatusValues]
     state: [StateFilter!]
 }


### PR DESCRIPTION
## Description

Github Tokens for Actions in the Cloudoperators organisation need to be defaulted to the read-only scope. 
Use [Github App Token](https://github.com/actions/create-github-app-token).

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert