### PR TITLE
chore: add lower_case_table_names=1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     image: mariadb:latest
     container_name: mariadb
     restart: always
+    command: --lower_case_table_names=1
     profiles:
       - db
     environment:


### PR DESCRIPTION
## Description

Fixes errors:

```
(HY000): Incorrect information in file: './heureka/issue.frm';
(HY000): Incorrect information in file: './heureka/service.frm';
```

when using DB Container on MacOs.

