### PR TITLE
fix(db): check issuematch id not null

### DIFF
--- a/internal/database/mariadb/migrations/20251031095712_mv_counters_replace_enum_rows_with_columns.up.sql
+++ b/internal/database/mariadb/migrations/20251031095712_mv_counters_replace_enum_rows_with_columns.up.sql
@@ -408,6 +408,7 @@ BEGIN
         AND I.issue_id = R.remediation_issue_id
         AND R.remediation_deleted_at IS NULL
     WHERE I.issue_deleted_at IS NULL
+      AND IM.issuematch_id IS NOT NULL
       AND (R.remediation_id IS NULL OR R.remediation_expiration_date < CURDATE())
     GROUP BY CI.componentinstance_service_id
     ON DUPLICATE KEY UPDATE


### PR DESCRIPTION
## Description

Check for `IM.issuematch_id IS NOT NULL` to prevent inserting row with service_id null.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
