### PR TITLE
fix(remediation): add data seeder for remediation type

### DIFF
--- a/internal/database/mariadb/remediation_test.go
+++ b/internal/database/mariadb/remediation_test.go
@@ -252,6 +252,26 @@ var _ = Describe("Remediation", Label("database", "Remediation"), func() {
 						}
 					})
 				})
+				It("can filter by 'false_positive' type", func() {
+					remediationType := entity.RemediationTypeFalsePositive.String()
+					filter := &entity.RemediationFilter{Type: []*string{&remediationType}}
+
+					entries, err := db.GetRemediations(filter, nil)
+
+					By("throwing no error", func() {
+						Expect(err).To(BeNil())
+					})
+
+					By("returning some results", func() {
+						Expect(entries).NotTo(BeEmpty())
+					})
+
+					By("returning entries include the type", func() {
+						for _, entry := range entries {
+							Expect(entry.Type).To(BeEquivalentTo(entity.RemediationTypeFalsePositive.String()))
+						}
+					})
+				})
 				It("can filter by 'risk_accepted' type", func() {
 					remediationType := entity.RemediationTypeRiskAccepted.String()
 					filter := &entity.RemediationFilter{Type: []*string{&remediationType}}
@@ -405,7 +425,7 @@ var _ = Describe("Remediation", Label("database", "Remediation"), func() {
 			By("throwing no error", func() {
 				Expect(err).To(BeNil())
 			})
-			weight := map[string]int{"None":1, "Low":2, "Medium":3, "High":4, "Critical":5}
+			weight := map[string]int{"None": 1, "Low": 2, "Medium": 3, "High": 4, "Critical": 5}
 			prevW := 100
 			for _, e := range entries {
 				w := weight[string(e.Severity)]

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -965,7 +965,7 @@ func (s *DatabaseSeeder) SeedRemediations(num int, services []mariadb.BaseServic
 			Severity:        sql.NullString{String: severity, Valid: true},
 			RemediationDate: sql.NullTime{Time: time.Now().AddDate(0, 0, rand.Intn(30)), Valid: true},
 			ExpirationDate:  sql.NullTime{Time: time.Now().AddDate(0, 1, rand.Intn(30)), Valid: true},
-			Type:            sql.NullString{String: entity.AllRemediationTypes[rand.Intn(len(entity.AllRemediationTypes))], Valid: true},
+			Type:            sql.NullString{String: entity.AllRemediationTypes[i%len(entity.AllRemediationTypes)], Valid: true},
 			ServiceId:       service.Id,
 			Service:         service.CCRN,
 			ComponentId:     component.Id,


### PR DESCRIPTION
## Description
In this PR I've added method that provides seeding different types of remediation in fixture to fix tests passing process

## What type of PR is this? (check all applicable)

- [+] 🐛 Bug Fix

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue https://github.com/cloudoperators/heureka/issues/1087
## Added tests?

- [+] 👍 yes

Added missing test for getting remediations with `false_positive` type

## Added to documentation?
- [+] 🙅 no documentation needed
