### PR TITLE
refactor(e2e): replace util2 with e2e_common in e2e tests

### DIFF
--- a/internal/e2e/authentication_test.go
+++ b/internal/e2e/authentication_test.go
@@ -15,7 +15,6 @@ import (
 	testentity "github.com/cloudoperators/heureka/internal/entity/test"
 	"github.com/cloudoperators/heureka/internal/util"
 	"github.com/cloudoperators/heureka/pkg/oidc"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 	"github.com/samber/lo"
 
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
@@ -113,16 +112,16 @@ func newAuthenticationTest() *authenticationTest {
 	db := dbm.NewTestSchemaWithoutMigration()
 
 	cfg := dbm.DbConfig()
-	cfg.Port = util2.GetRandomFreePort()
+	cfg.Port = e2e_common.GetRandomFreePort()
 	cfg.AuthOidcClientId = "mock-client-id"
-	cfg.AuthOidcUrl = fmt.Sprintf("http://localhost:%s", util2.GetRandomFreePort())
+	cfg.AuthOidcUrl = fmt.Sprintf("http://localhost:%s", e2e_common.GetRandomFreePort())
 	oidcProvider := oidc.NewProvider(cfg.AuthOidcUrl, enableOidcProviderLog)
 	oidcProvider.Start()
 
 	seeder, err := test.NewDatabaseSeeder(cfg)
 	Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
-	cfg.Port = util2.GetRandomFreePort()
+	cfg.Port = e2e_common.GetRandomFreePort()
 	server := e2e_common.NewRunningServer(cfg)
 
 	seedCollection := seeder.SeedDbWithNFakeData(defaultTestFakeDataItems)

--- a/internal/e2e/cache_test.go
+++ b/internal/e2e/cache_test.go
@@ -9,7 +9,6 @@ import (
 
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/app/service"
 	"github.com/cloudoperators/heureka/internal/server"
@@ -73,7 +72,7 @@ func newCacheTest(valkeyUrl string, ttl time.Duration, maxDbConcurrentRefreshes 
 		ct.startDbProxy()
 	}
 
-	ct.cfg.Port = util2.GetRandomFreePort()
+	ct.cfg.Port = e2e_common.GetRandomFreePort()
 	ct.cfg.CacheEnable = true
 	ct.cfg.CacheValkeyUrl = valkeyUrl
 	ct.cfg.CacheMaxDbConcurrentRefreshes = maxDbConcurrentRefreshes
@@ -90,7 +89,7 @@ func newCacheTest(valkeyUrl string, ttl time.Duration, maxDbConcurrentRefreshes 
 
 func (ct *cacheTest) startDbProxy() {
 	dbPort := ct.cfg.DBPort
-	dbProxyPort := util2.GetRandomFreePort()
+	dbProxyPort := e2e_common.GetRandomFreePort()
 	ct.dbProxy = e2e_common.NewPausableProxy(fmt.Sprintf("localhost:%s", dbProxyPort), fmt.Sprintf("localhost:%s", dbPort))
 	err := ct.dbProxy.Start()
 	Expect(err).To(BeNil(), "Could not start DB proxy")

--- a/internal/e2e/common/gql.go
+++ b/internal/e2e/common/gql.go
@@ -12,6 +12,10 @@ import (
 	"github.com/machinebox/graphql"
 )
 
+func GetRandomFreePort() string {
+	return util2.GetRandomFreePort()
+}
+
 var GqlStandardHeaders map[string]string = map[string]string{
 	"Cache-Control": "no-cache",
 }

--- a/internal/e2e/db_migration_test.go
+++ b/internal/e2e/db_migration_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
+	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/server"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -161,7 +161,7 @@ func (dbmt *DbMigrationTest) setup() {
 	dbmt.heurekaMigration = mariadb.MigrationFs
 	dbmt.db = dbm.NewTestSchemaWithoutMigration()
 	dbmt.cfg = dbm.DbConfig()
-	dbmt.cfg.Port = util2.GetRandomFreePort()
+	dbmt.cfg.Port = e2e_common.GetRandomFreePort()
 }
 
 func (dbmt *DbMigrationTest) teardown() {

--- a/internal/e2e/image_query_test.go
+++ b/internal/e2e/image_query_test.go
@@ -9,7 +9,6 @@ import (
 
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 	"github.com/samber/lo"
 
 	"github.com/cloudoperators/heureka/internal/server"
@@ -115,7 +114,7 @@ func newImageTest() *imageTest {
 	db := dbm.NewTestSchemaWithoutMigration()
 
 	cfg := dbm.DbConfig()
-	cfg.Port = util2.GetRandomFreePort()
+	cfg.Port = e2e_common.GetRandomFreePort()
 
 	seeder, err := test.NewDatabaseSeeder(cfg)
 	Expect(err).To(BeNil(), "Database Seeder Setup should work")

--- a/internal/e2e/image_version_query_test.go
+++ b/internal/e2e/image_version_query_test.go
@@ -9,7 +9,6 @@ import (
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
@@ -33,7 +32,7 @@ var _ = Describe("Getting ImageVersions via API", Label("e2e", "ImageVersions"),
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 

--- a/internal/e2e/issue_variant_query_test.go
+++ b/internal/e2e/issue_variant_query_test.go
@@ -4,26 +4,21 @@
 package e2e_test
 
 import (
-	"context"
 	"fmt"
-	"os"
 
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
 	testentity "github.com/cloudoperators/heureka/internal/entity/test"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
-	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Getting IssueVariants via API", Label("e2e", "IssueVariants"), func() {
@@ -39,7 +34,7 @@ var _ = Describe("Getting IssueVariants via API", Label("e2e", "IssueVariants"),
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -50,30 +45,20 @@ var _ = Describe("Getting IssueVariants via API", Label("e2e", "IssueVariants"),
 
 	When("the database is empty", func() {
 		It("returns empty resultset", func() {
-			// create a queryCollection (safe to share across requests)
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-			//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/minimal.graphql")
-
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-
-			req.Var("filter", map[string]string{})
-			req.Var("first", 10)
-			req.Var("after", "0")
-
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-
-			var respData struct {
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 				IssueVariants model.IssueVariantConnection `json:"IssueVariants"`
-			}
-			if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-			}
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/issueVariant/minimal.graphql",
+				map[string]any{
+					"filter": map[string]string{},
+					"first":  10,
+					"after":  "0",
+				},
+				nil,
+			)
 
+			Expect(err).ToNot(HaveOccurred())
 			Expect(respData.IssueVariants.TotalCount).To(Equal(0))
 		})
 	})
@@ -85,59 +70,45 @@ var _ = Describe("Getting IssueVariants via API", Label("e2e", "IssueVariants"),
 		})
 		Context("and no additional filters are present", func() {
 			It("returns correct result count", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/minimal.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("filter", map[string]string{})
-				req.Var("first", 5)
-				req.Var("after", "0")
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					IssueVariants model.IssueVariantConnection `json:"IssueVariants"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/minimal.graphql",
+					map[string]any{
+						"filter": map[string]string{},
+						"first":  5,
+						"after":  "0",
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(respData.IssueVariants.TotalCount).To(Equal(len(seedCollection.IssueVariantRows)))
 				Expect(len(respData.IssueVariants.Edges)).To(Equal(5))
 			})
 		})
 		Context("and we query to resolve levels of relations", Label("directRelations.graphql"), func() {
-			var respData struct {
+			respData := struct {
 				IssueVariants model.IssueVariantConnection `json:"IssueVariants"`
-			}
+			}{}
 			BeforeEach(func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
+				resp, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
+					IssueVariants model.IssueVariantConnection `json:"IssueVariants"`
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/directRelations.graphql",
+					map[string]any{
+						"filter": map[string]string{},
+						"first":  5,
+						"after":  "0",
+					},
+					nil,
+				)
 
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/directRelations.graphql")
+				Expect(err).ToNot(HaveOccurred())
 
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("filter", map[string]string{})
-				req.Var("first", 5)
-				req.Var("after", "0")
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				err = client.Run(ctx, req, &respData)
-
-				Expect(err).To(BeNil(), "Error while unmarshaling")
+				respData = resp
 			})
 
 			It("- returns the correct result count", func() {
@@ -203,7 +174,7 @@ var _ = Describe("Creating IssueVariant via API", Label("e2e", "IssueVariants"),
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -223,36 +194,26 @@ var _ = Describe("Creating IssueVariant via API", Label("e2e", "IssueVariants"),
 
 		Context("and a mutation query is performed", Label("create.graphql"), func() {
 			It("creates new issueVariant with Vector", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/create.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("input", map[string]interface{}{
-					"secondaryName":     issueVariant.SecondaryName,
-					"description":       issueVariant.Description,
-					"issueRepositoryId": fmt.Sprintf("%d", issueVariant.IssueRepositoryId),
-					"issueId":           fmt.Sprintf("%d", issueVariant.IssueId),
-					"severity": map[string]string{
-						"vector": issueVariant.Severity.Cvss.Vector,
-					},
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					IssueVariant model.IssueVariant `json:"createIssueVariant"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/create.graphql",
+					map[string]any{
+						"input": map[string]interface{}{
+							"secondaryName":     issueVariant.SecondaryName,
+							"description":       issueVariant.Description,
+							"issueRepositoryId": fmt.Sprintf("%d", issueVariant.IssueRepositoryId),
+							"issueId":           fmt.Sprintf("%d", issueVariant.IssueId),
+							"severity": map[string]string{
+								"vector": issueVariant.Severity.Cvss.Vector,
+							},
+						},
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(*respData.IssueVariant.SecondaryName).To(Equal(issueVariant.SecondaryName))
 				Expect(*respData.IssueVariant.Description).To(Equal(issueVariant.Description))
 				Expect(*respData.IssueVariant.IssueRepositoryID).To(Equal(fmt.Sprintf("%d", issueVariant.IssueRepositoryId)))
@@ -260,37 +221,27 @@ var _ = Describe("Creating IssueVariant via API", Label("e2e", "IssueVariants"),
 				Expect(*respData.IssueVariant.Severity.Cvss.Vector).To(Equal(issueVariant.Severity.Cvss.Vector))
 			})
 			It("creates new issueVariant with Rating", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/createWithRating.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("input", map[string]interface{}{
-					"secondaryName":     issueVariant.SecondaryName,
-					"description":       issueVariant.Description,
-					"externalUrl":       issueVariant.ExternalUrl,
-					"issueRepositoryId": fmt.Sprintf("%d", issueVariant.IssueRepositoryId),
-					"issueId":           fmt.Sprintf("%d", issueVariant.IssueId),
-					"severity": map[string]string{
-						"rating": issueVariant.Severity.Value,
-					},
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					IssueVariant model.IssueVariant `json:"createIssueVariant"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/createWithRating.graphql",
+					map[string]any{
+						"input": map[string]interface{}{
+							"secondaryName":     issueVariant.SecondaryName,
+							"description":       issueVariant.Description,
+							"externalUrl":       issueVariant.ExternalUrl,
+							"issueRepositoryId": fmt.Sprintf("%d", issueVariant.IssueRepositoryId),
+							"issueId":           fmt.Sprintf("%d", issueVariant.IssueId),
+							"severity": map[string]string{
+								"rating": issueVariant.Severity.Value,
+							},
+						},
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(*respData.IssueVariant.SecondaryName).To(Equal(issueVariant.SecondaryName))
 				Expect(*respData.IssueVariant.Description).To(Equal(issueVariant.Description))
 				Expect(*respData.IssueVariant.ExternalURL).To(Equal(issueVariant.ExternalUrl))
@@ -315,7 +266,7 @@ var _ = Describe("Updating issueVariant via API", Label("e2e", "IssueVariants"),
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -333,77 +284,54 @@ var _ = Describe("Updating issueVariant via API", Label("e2e", "IssueVariants"),
 
 		Context("and a mutation query is performed", Label("update.graphql"), func() {
 			It("updates issueVariant", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/update.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
 				ir := seedCollection.IssueRepositoryRows[0].AsIssueRepository()
 				issueVariant := seedCollection.IssueVariantRows[0].AsIssueVariant(&ir)
 				issueVariant.SecondaryName = "SecretIssueVariant"
 				issueVariant.ExternalUrl = "https://new.com"
 
-				req.Var("id", fmt.Sprintf("%d", issueVariant.Id))
-				req.Var("input", map[string]string{
-					"secondaryName": issueVariant.SecondaryName,
-					"externalUrl":   issueVariant.ExternalUrl,
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					IssueVariant model.IssueVariant `json:"updateIssueVariant"`
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/update.graphql",
+					map[string]any{
+						"id": fmt.Sprintf("%d", issueVariant.Id),
+						"input": map[string]interface{}{
+							"secondaryName": issueVariant.SecondaryName,
+							"externalUrl":   issueVariant.ExternalUrl,
+						},
+					},
+					nil,
+				)
 
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
-
+				Expect(err).ToNot(HaveOccurred())
 				Expect(*respData.IssueVariant.SecondaryName).To(Equal(issueVariant.SecondaryName))
 				Expect(*respData.IssueVariant.ExternalURL).To(Equal(issueVariant.ExternalUrl))
 			})
 			It("updates issueVariant severity with rating", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/update.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				newRating := model.SeverityValuesLow
-
 				ir := seedCollection.IssueRepositoryRows[0].AsIssueRepository()
 				issueVariant := seedCollection.IssueVariantRows[0].AsIssueVariant(&ir)
 
+				newRating := model.SeverityValuesLow
 				issueVariant.Severity.Value = string(newRating)
 
-				req.Var("id", fmt.Sprintf("%d", issueVariant.Id))
-				req.Var("input", map[string]interface{}{
-					"severity": model.SeverityInput{
-						Rating: &newRating,
-					},
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					IssueVariant model.IssueVariant `json:"updateIssueVariant"`
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/update.graphql",
+					map[string]any{
+						"id": fmt.Sprintf("%d", issueVariant.Id),
+						"input": map[string]interface{}{
+							"severity": model.SeverityInput{
+								Rating: &newRating,
+							},
+						},
+					},
+					nil,
+				)
 
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
-
+				Expect(err).ToNot(HaveOccurred())
 				Expect(string(*respData.IssueVariant.Severity.Value)).To(Equal(issueVariant.Severity.Value))
 				if respData.IssueVariant.Severity.Cvss != nil && respData.IssueVariant.Severity.Cvss.Vector != nil {
 					Expect(string(*respData.IssueVariant.Severity.Cvss.Vector)).To(BeEmpty())
@@ -426,7 +354,7 @@ var _ = Describe("Deleting IssueVariant via API", Label("e2e", "IssueVariants"),
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -444,30 +372,20 @@ var _ = Describe("Deleting IssueVariant via API", Label("e2e", "IssueVariants"),
 
 		Context("and a mutation query is performed", Label("delete.graphql"), func() {
 			It("deletes issue variant", func() {
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/issueVariant/delete.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
 				id := fmt.Sprintf("%d", seedCollection.IssueVariantRows[0].Id.Int64)
 
-				req.Var("id", id)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Id string `json:"deleteIssueVariant"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/issueVariant/delete.graphql",
+					map[string]any{
+						"id": id,
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(respData.Id).To(Equal(id))
 			})
 		})

--- a/internal/e2e/metadata_test.go
+++ b/internal/e2e/metadata_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/cloudoperators/heureka/internal/server"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,7 +93,7 @@ var _ = Describe("Creating, updating and state filtering of entity via API", Lab
 		db = dbm.NewTestSchemaWithoutMigration()
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 

--- a/internal/e2e/oidc_auth_test.go
+++ b/internal/e2e/oidc_auth_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cloudoperators/heureka/pkg/oidc"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/access/test"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -32,9 +31,9 @@ var _ = Describe("Getting access via API", Label("e2e", "OidcAuthorization"), fu
 	BeforeEach(func() {
 		db = dbm.NewTestSchemaWithoutMigration()
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		cfg.AuthOidcClientId = "mock-client-id"
-		cfg.AuthOidcUrl = fmt.Sprintf("http://localhost:%s", util2.GetRandomFreePort())
+		cfg.AuthOidcUrl = fmt.Sprintf("http://localhost:%s", e2e_common.GetRandomFreePort())
 		oidcProvider = oidc.NewProvider(cfg.AuthOidcUrl, enableOidcProviderLog)
 		oidcProvider.Start()
 

--- a/internal/e2e/patch_query_test.go
+++ b/internal/e2e/patch_query_test.go
@@ -8,7 +8,6 @@ import (
 
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
@@ -33,7 +32,7 @@ var _ = Describe("Getting Patches via API", Label("e2e", "Patches"), func() {
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 

--- a/internal/e2e/query_batch_limit_test.go
+++ b/internal/e2e/query_batch_limit_test.go
@@ -6,7 +6,6 @@ package e2e_test
 import (
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
@@ -68,7 +67,7 @@ var _ = Describe("Getting data via API", Label("e2e", "Batch Limiting"), func() 
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		// Set batch limit as 2 for testing pourpose
 		cfg.GQLBatchLimit = 2
 		s = e2e_common.NewRunningServer(cfg)

--- a/internal/e2e/query_depth_limit_test.go
+++ b/internal/e2e/query_depth_limit_test.go
@@ -6,7 +6,6 @@ package e2e_test
 import (
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
@@ -92,7 +91,7 @@ var _ = Describe("Getting data via API", Label("e2e", "Depth Limiting"), func() 
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		// Set depth limit as 10 for testing pourpose
 		cfg.GQLDepthLimit = 10
 		s = e2e_common.NewRunningServer(cfg)

--- a/internal/e2e/remediation_query_test.go
+++ b/internal/e2e/remediation_query_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudoperators/heureka/internal/entity"
 	testentity "github.com/cloudoperators/heureka/internal/entity/test"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
@@ -36,7 +35,7 @@ var _ = Describe("Getting Remediations via API", Label("e2e", "Remediations"), f
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -128,7 +127,7 @@ var _ = Describe("Creating Remediation via API", Label("e2e", "Remediations"), f
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -194,7 +193,7 @@ var _ = Describe("Updating remediation via API", Label("e2e", "Remediations"), f
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -308,7 +307,7 @@ var _ = Describe("Deleting Remediation via API", Label("e2e", "Remediations"), f
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 

--- a/internal/e2e/scanner_run_query_test.go
+++ b/internal/e2e/scanner_run_query_test.go
@@ -4,22 +4,15 @@
 package e2e_test
 
 import (
-	"context"
-	"fmt"
-	"os"
-
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
-	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func() {
@@ -31,7 +24,7 @@ var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func
 		db = dbm.NewTestSchemaWithoutMigration()
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -46,31 +39,21 @@ var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func
 				sampleTag := gofakeit.Word()
 				sampleUUID := gofakeit.UUID()
 
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/create.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("input", map[string]string{
-					"tag":  sampleTag,
-					"uuid": sampleUUID,
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result bool `json:"createScannerRun"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/create.graphql",
+					map[string]any{
+						"input": map[string]string{
+							"tag":  sampleTag,
+							"uuid": sampleUUID,
+						},
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(respData.Result).To(BeTrue())
 			})
 		})
@@ -80,52 +63,35 @@ var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func
 				sampleTag := gofakeit.Word()
 				sampleUUID := gofakeit.UUID()
 
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/create.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("input", map[string]string{
-					"tag":  sampleTag,
-					"uuid": sampleUUID,
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result bool `json:"createScannerRun"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/create.graphql",
+					map[string]any{
+						"input": map[string]string{
+							"tag":  sampleTag,
+							"uuid": sampleUUID,
+						},
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(respData.Result).To(BeTrue())
 
-				b, err = os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/complete.graphql")
-
-				Expect(err).To(BeNil())
-				str = string(b)
-				new_req := graphql.NewRequest(str)
-
-				new_req.Var("uuid", sampleUUID)
-
-				new_req.Header.Set("Cache-Control", "no-cache")
-				ctx = context.Background()
-
-				var newRespData struct {
+				newRespData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result bool `json:"completeScannerRun"`
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/complete.graphql",
+					map[string]any{
+						"uuid": sampleUUID,
+					},
+					nil,
+				)
 
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, new_req, &newRespData) }); err != nil {
-					logrus.WithError(err).WithField("request", new_req).Fatalln("Error while unmarshaling")
-				}
-
+				Expect(err).ToNot(HaveOccurred())
 				Expect(newRespData.Result).To(BeTrue())
 			})
 		})
@@ -136,53 +102,36 @@ var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func
 				sampleUUID := gofakeit.UUID()
 				sampleMessage := gofakeit.Sentence()
 
-				// create a queryCollection (safe to share across requests)
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/create.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Var("input", map[string]string{
-					"tag":  sampleTag,
-					"uuid": sampleUUID,
-				})
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result bool `json:"createScannerRun"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/create.graphql",
+					map[string]any{
+						"input": map[string]string{
+							"tag":  sampleTag,
+							"uuid": sampleUUID,
+						},
+					},
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(respData.Result).To(BeTrue())
 
-				b, err = os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/fail.graphql")
-
-				Expect(err).To(BeNil())
-				str = string(b)
-				new_req := graphql.NewRequest(str)
-
-				new_req.Var("message", sampleMessage)
-				new_req.Var("uuid", sampleUUID)
-
-				new_req.Header.Set("Cache-Control", "no-cache")
-				ctx = context.Background()
-
-				var newRespData struct {
+				newRespData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result bool `json:"failScannerRun"`
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/fail.graphql",
+					map[string]any{
+						"message": sampleMessage,
+						"uuid":    sampleUUID,
+					},
+					nil,
+				)
 
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, new_req, &newRespData) }); err != nil {
-					logrus.WithError(err).WithField("request", new_req).Fatalln("Error while unmarshaling")
-				}
-
+				Expect(err).ToNot(HaveOccurred())
 				Expect(newRespData.Result).To(BeTrue())
 			})
 		})
@@ -192,16 +141,14 @@ var _ = Describe("Creating ScannerRun via API", Label("e2e", "ScannerRun"), func
 var _ = Describe("Querying ScannerRun via API", Label("e2e", "ScannerRun"), func() {
 	var s *server.Server
 	var cfg util.Config
-	var client *graphql.Client
 	var db *mariadb.SqlDatabase
 
 	BeforeEach(func() {
 		db = dbm.NewTestSchemaWithoutMigration()
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
-		client = graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
 	})
 
 	AfterEach(func() {
@@ -212,35 +159,24 @@ var _ = Describe("Querying ScannerRun via API", Label("e2e", "ScannerRun"), func
 	When("the database is empty", func() {
 		Context("and a query for scannerruns is performed", Label("create.graphql"), func() {
 			It("returns an empty list", func() {
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/scannerRun/scannerruns.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				graphql.NewRequest(str)
-
-				new_req := graphql.NewRequest(str)
-
-				new_req.Header.Set("Cache-Control", "no-cache")
-
-				new_req.Var("filter", struct {
-					Tag       []string `json:"tag"`
-					Completed bool     `json:"completed"`
-				}{Tag: []string{}, Completed: false})
-
-				new_req.Var("first", 10)
-				new_req.Var("after", 0)
-
-				ctx := context.Background()
-
-				var newRespData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					Result int `json:"totalCount"`
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/scannerRun/scannerruns.graphql",
+					map[string]any{
+						"filter": map[string]any{
+							"tag":       []string{},
+							"completed": false,
+						},
+						"first": 10,
+						"after": 0,
+					},
+					nil,
+				)
 
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, new_req, &newRespData) }); err != nil {
-					logrus.WithError(err).WithField("request", new_req).Fatalln("Error while unmarshaling")
-				}
-
-				Expect(newRespData.Result).To(Equal(0))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(respData.Result).To(Equal(0))
 			})
 		})
 	})

--- a/internal/e2e/service_filter_query_test.go
+++ b/internal/e2e/service_filter_query_test.go
@@ -4,12 +4,9 @@
 package e2e_test
 
 import (
-	"context"
 	"fmt"
-	"os"
 
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
@@ -17,11 +14,9 @@ import (
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
-	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFilterValues"), func() {
@@ -37,7 +32,7 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -48,89 +43,55 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 
 	When("the database is empty", func() {
 		It("returns empty resultset for serviceFilter", func() {
-			// create a queryCollection (safe to share across requests)
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-			//@todo may need to make this more fault proof?! What if the test is executed from the root dir? does it still work?
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql")
-
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-
-			var respData struct {
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 				ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-			}
-			if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-			}
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql",
+				nil,
+				nil,
+			)
 
+			Expect(err).ToNot(HaveOccurred())
 			Expect(respData.ServiceFilterValues.ServiceCcrn.Values).To(BeEmpty())
 		})
 		It("returns empty for supportGroupCcrns", func() {
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql")
-
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-
-			var respData struct {
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 				ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-			}
-			if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-			}
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql",
+				nil,
+				nil,
+			)
 
+			Expect(err).ToNot(HaveOccurred())
 			Expect(respData.ServiceFilterValues.SupportGroupCcrn.Values).To(BeEmpty())
 		})
 		It("returns empty for userNames", func() {
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/userNames.graphql")
-
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-
-			var respData struct {
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 				ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-			}
-			if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-			}
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/serviceFilter/userNames.graphql",
+				nil,
+				nil,
+			)
 
+			Expect(err).ToNot(HaveOccurred())
 			e2e_common.ExpectNonSystemUserNames(respData.ServiceFilterValues.UserName.Values, []*string{})
 		})
 		It("returns empty for uniqueUserID", func() {
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/uniqueUserId.graphql")
-
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-
-			var respData struct {
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 				ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-			}
-			if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-				logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-			}
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/serviceFilter/uniqueUserId.graphql",
+				nil,
+				nil,
+			)
 
+			Expect(err).ToNot(HaveOccurred())
 			e2e_common.ExpectNonSystemUserUniqueUserIds(respData.ServiceFilterValues.UniqueUserID.Values, []*string{})
 		})
 	})
@@ -142,24 +103,16 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 		})
 		Context("and no additional filters are present", func() {
 			It("returns correct serviceCcrns", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/serviceFilter/serviceCcrns.graphql",
+					nil,
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(len(respData.ServiceFilterValues.ServiceCcrn.Values)).To(Equal(len(seedCollection.ServiceRows)))
 
 				existingServiceCcrns := lo.Map(seedCollection.ServiceRows, func(s mariadb.BaseServiceRow, index int) string {
@@ -171,23 +124,16 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				}
 			})
 			It("returns correct supportGroupCcrns", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/serviceFilter/supportGroupCcrns.graphql",
+					nil,
+					nil,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(respData.ServiceFilterValues.SupportGroupCcrn.Values)).To(Equal(len(seedCollection.SupportGroupRows)))
 
@@ -200,23 +146,16 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				}
 			})
 			It("returns correct userNames", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/userNames.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/serviceFilter/userNames.graphql",
+					nil,
+					nil,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
 
 				e2e_common.ExpectNonSystemUserCount(len(respData.ServiceFilterValues.UserName.Values), len(seedCollection.UserRows))
 
@@ -229,23 +168,16 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				}
 			})
 			It("returns correct UniqueUserID", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/uniqueUserId.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/serviceFilter/uniqueUserId.graphql",
+					nil,
+					nil,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
 
 				e2e_common.ExpectNonSystemUserCount(len(respData.ServiceFilterValues.UniqueUserID.Values), len(seedCollection.UserRows))
 
@@ -258,23 +190,16 @@ var _ = Describe("Getting ServiceFilterValues via API", Label("e2e", "ServiceFil
 				}
 			})
 			It("returns correct Name With Id", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/serviceFilter/userNamesWithIds.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					ServiceFilterValues model.ServiceFilterValue `json:"ServiceFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/serviceFilter/userNamesWithIds.graphql",
+					nil,
+					nil,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
 
 				e2e_common.ExpectNonSystemUserCount(len(respData.ServiceFilterValues.User.Values), len(seedCollection.UserRows))
 

--- a/internal/e2e/siem_alert_test.go
+++ b/internal/e2e/siem_alert_test.go
@@ -9,7 +9,6 @@ import (
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
@@ -32,7 +31,7 @@ var _ = Describe("Creating SIEMAlert via API", Label("e2e", "SIEMAlert"), func()
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 

--- a/internal/e2e/token_auth_test.go
+++ b/internal/e2e/token_auth_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cloudoperators/heureka/internal/util"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/access/test"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,7 +27,7 @@ var _ = Describe("Getting access via API", Label("e2e", "TokenAuthorization"), f
 	BeforeEach(func() {
 		db = dbm.NewTestSchemaWithoutMigration()
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		cfg.AuthTokenSecret = "xxx"
 		s = e2e_common.NewRunningServer(cfg)
 		queryUrl = fmt.Sprintf("http://localhost:%s/query", cfg.Port)

--- a/internal/e2e/vulnerability_filter_query_test.go
+++ b/internal/e2e/vulnerability_filter_query_test.go
@@ -4,24 +4,17 @@
 package e2e_test
 
 import (
-	"context"
-	"fmt"
-	"os"
-
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
-	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Getting VulnerabilityFilterValues via API", Label("e2e", "VulnerabilityFilterValues"), func() {
@@ -37,7 +30,7 @@ var _ = Describe("Getting VulnerabilityFilterValues via API", Label("e2e", "Vuln
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -53,24 +46,16 @@ var _ = Describe("Getting VulnerabilityFilterValues via API", Label("e2e", "Vuln
 		})
 		Context("and no additional filters are present", func() {
 			It("returns correct supportGroups", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/vulnerabilityFilter/supportGroup.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					VulnerabilityFilterValues model.VulnerabilityFilterValue `json:"VulnerabilityFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/vulnerabilityFilter/supportGroup.graphql",
+					nil,
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(len(respData.VulnerabilityFilterValues.SupportGroup.Values)).To(Equal(len(seedCollection.SupportGroupRows)))
 
 				existingsupportGroupCcrns := lo.Map(seedCollection.SupportGroupRows, func(s mariadb.SupportGroupRow, index int) string {
@@ -82,24 +67,16 @@ var _ = Describe("Getting VulnerabilityFilterValues via API", Label("e2e", "Vuln
 				}
 			})
 			It("returns correct severities", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/vulnerabilityFilter/severity.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					VulnerabilityFilterValues model.VulnerabilityFilterValue `json:"VulnerabilityFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/vulnerabilityFilter/severity.graphql",
+					nil,
+					nil,
+				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(len(respData.VulnerabilityFilterValues.Severity.Values)).To(Equal(len(model.AllSeverityValues)))
 				for _, severity := range respData.VulnerabilityFilterValues.Severity.Values {
 					allSeverityValues := lo.Map(model.AllSeverityValues, func(s model.SeverityValues, _ int) string {
@@ -109,23 +86,16 @@ var _ = Describe("Getting VulnerabilityFilterValues via API", Label("e2e", "Vuln
 				}
 			})
 			It("returns correct services", func() {
-				client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-
-				b, err := os.ReadFile("../api/graphql/graph/queryCollection/vulnerabilityFilter/service.graphql")
-
-				Expect(err).To(BeNil())
-				str := string(b)
-				req := graphql.NewRequest(str)
-
-				req.Header.Set("Cache-Control", "no-cache")
-				ctx := context.Background()
-
-				var respData struct {
+				respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
 					VulnerabilityFilterValues model.VulnerabilityFilterValue `json:"VulnerabilityFilterValues"`
-				}
-				if err := util2.RequestWithBackoff(func() error { return client.Run(ctx, req, &respData) }); err != nil {
-					logrus.WithError(err).WithField("request", req).Fatalln("Error while unmarshaling")
-				}
+				}](
+					cfg.Port,
+					"../api/graphql/graph/queryCollection/vulnerabilityFilter/service.graphql",
+					nil,
+					nil,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(respData.VulnerabilityFilterValues.Service.Values)).To(Equal(len(seedCollection.ServiceRows)))
 

--- a/internal/e2e/vulnerability_query_test.go
+++ b/internal/e2e/vulnerability_query_test.go
@@ -4,21 +4,15 @@
 package e2e_test
 
 import (
-	"context"
-	"fmt"
-	"os"
-
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/cloudoperators/heureka/internal/util"
-	util2 "github.com/cloudoperators/heureka/pkg/util"
 
 	"github.com/cloudoperators/heureka/internal/server"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
-	"github.com/machinebox/graphql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -36,7 +30,7 @@ var _ = Describe("Getting Vulnerabilities via API", Label("e2e", "Vulnerabilitie
 		Expect(err).To(BeNil(), "Database Seeder Setup should work")
 
 		cfg = dbm.DbConfig()
-		cfg.Port = util2.GetRandomFreePort()
+		cfg.Port = e2e_common.GetRandomFreePort()
 		s = e2e_common.NewRunningServer(cfg)
 	})
 
@@ -65,9 +59,6 @@ var _ = Describe("Getting Vulnerabilities via API", Label("e2e", "Vulnerabilitie
 		return componentInstances, issueVariants, cvIssues, issueMatches, nil
 	}
 	When("the database has 10 issues", func() {
-		var respData struct {
-			Vulnerabilities model.VulnerabilityConnection `json:"Vulnerabilities"`
-		}
 		var counts model.SeverityCounts
 		BeforeEach(func() {
 			seeder.SeedIssueRepositories()
@@ -116,18 +107,20 @@ var _ = Describe("Getting Vulnerabilities via API", Label("e2e", "Vulnerabilitie
 		})
 
 		It("returns the expected content and the expected PageInfo", func() {
-			client := graphql.NewClient(fmt.Sprintf("http://localhost:%s/query", cfg.Port))
-			b, err := os.ReadFile("../api/graphql/graph/queryCollection/vulnerability/query.graphql")
-			Expect(err).To(BeNil())
-			str := string(b)
-			req := graphql.NewRequest(str)
-			req.Var("filter", map[string]string{})
-			req.Var("first", 5)
-			req.Var("after", "")
-			req.Header.Set("Cache-Control", "no-cache")
-			ctx := context.Background()
-			err = client.Run(ctx, req, &respData)
-			Expect(err).To(BeNil(), "Error while unmarshaling")
+			respData, err := e2e_common.ExecuteGqlQueryFromFileWithHeaders[struct {
+				Vulnerabilities model.VulnerabilityConnection `json:"Vulnerabilities"`
+			}](
+				cfg.Port,
+				"../api/graphql/graph/queryCollection/vulnerability/query.graphql",
+				map[string]any{
+					"filter": map[string]string{},
+					"first":  5,
+					"after":  "",
+				},
+				nil,
+			)
+
+			Expect(err).ToNot(HaveOccurred())
 			Expect(respData.Vulnerabilities.TotalCount).To(Equal(10))
 			Expect(len(respData.Vulnerabilities.Edges)).To(Equal(5))
 			var prevSeverity int = 100


### PR DESCRIPTION
## Description
In this PR I've replaced GraphQL requests in e2e tests using `util2` with `e2e_common` using generic approach

## What type of PR is this? (check all applicable)
- [+] 🧑‍💻 Code Refactor
## Related Tickets & Documents

- Related Issue https://github.com/cloudoperators/heureka/issues/1103

## Added tests?
- [+] 🙅 no, because they aren't needed

## Added to documentation?
- [+] 🙅 no documentation needed
