### PR TITLE
fix(keppel): check if OS is nil

### DIFF
--- a/scanner/keppel/processor/processor.go
+++ b/scanner/keppel/processor/processor.go
@@ -234,7 +234,7 @@ func (p *Processor) ProcessReport(report models.TrivyReport, componentVersionId 
 		}
 	}
 
-	if report.Metadata.OS.Eosl {
+	if report.Metadata.OS != nil && report.Metadata.OS.Eosl {
 		_, err := client.UpdateComponentVersion(
 			context.Background(),
 			*p.Client,


### PR DESCRIPTION
## Description

If `report.Metadata.OS` is `nil` the keppel scanner crashes.