### PR TITLE
fix: refresh_mvCountIssueRatingsServiceId_proc

### DIFF
--- a/internal/database/mariadb/migration.go
+++ b/internal/database/mariadb/migration.go
@@ -73,7 +73,8 @@ func (s *SqlDatabase) openMigration() (*migrate.Migrate, error) {
 
 	m, err := migrate.NewWithInstance(
 		"iofs", d,
-		"mysql", driver)
+		"mysql", driver,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ func (s *SqlDatabase) proceduresExist(procedures []string) (bool, error) {
 
 func (s *SqlDatabase) runPostMigrationProcessInBackground(procs []string) {
 	s.runPostMigrationProceduresInBackground(procs)
-	s.runPostMigrationCleanupRoutineInBackground(procs)
+	s.runPostMigrationCleanupRoutineInBackground()
 }
 
 func (s *SqlDatabase) runPostMigrationProceduresInBackground(procs []string) {
@@ -416,7 +417,7 @@ func (s *SqlDatabase) runPostMigrationProceduresInBackground(procs []string) {
 	}
 }
 
-func (s *SqlDatabase) runPostMigrationCleanupRoutineInBackground(procs []string) {
+func (s *SqlDatabase) runPostMigrationCleanupRoutineInBackground() {
 	go func() {
 		if err := s.WaitPostMigrations(); err != nil {
 			logrus.WithError(err).Error(err)

--- a/internal/database/mariadb/migrations/20260504154924_change_join_kind.down.sql
+++ b/internal/database/mariadb/migrations/20260504154924_change_join_kind.down.sql
@@ -1,0 +1,59 @@
+DROP PROCEDURE IF EXISTS refresh_mvCountIssueRatingsServiceId_proc;
+
+CREATE PROCEDURE refresh_mvCountIssueRatingsServiceId_proc()
+BEGIN
+    UPDATE mvCountIssueRatingsServiceId
+    SET is_active = 0
+    WHERE is_active = 1;
+
+    INSERT INTO mvCountIssueRatingsServiceId (
+        service_id,
+        service_ccrn,
+        critical_count,
+        high_count,
+        medium_count,
+        low_count,
+        none_count,
+        is_active
+    )
+    SELECT
+        CI.componentinstance_service_id,
+        S.service_ccrn,
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Critical'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'High'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Medium'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Low'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'None'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        1
+    FROM Issue I
+    LEFT JOIN IssueVariant IV ON IV.issuevariant_issue_id = I.issue_id
+    LEFT JOIN IssueMatch IM ON I.issue_id = IM.issuematch_issue_id
+    LEFT JOIN ComponentInstance CI
+        ON CI.componentinstance_id = IM.issuematch_component_instance_id
+       AND CI.componentinstance_deleted_at IS NULL
+    LEFT JOIN Service S ON S.service_id = CI.componentinstance_service_id
+    LEFT JOIN Remediation R
+        ON CI.componentinstance_service_id = R.remediation_service_id
+       AND I.issue_id = R.remediation_issue_id
+       AND R.remediation_deleted_at IS NULL
+    WHERE I.issue_deleted_at IS NULL
+      AND IM.issuematch_id IS NOT NULL
+      AND (R.remediation_id IS NULL OR R.remediation_expiration_date < CURDATE())
+    GROUP BY CI.componentinstance_service_id
+    ON DUPLICATE KEY UPDATE
+        service_ccrn   = VALUES(service_ccrn),
+        critical_count = VALUES(critical_count),
+        high_count     = VALUES(high_count),
+        medium_count   = VALUES(medium_count),
+        low_count      = VALUES(low_count),
+        none_count     = VALUES(none_count),
+        is_active      = 1;
+
+    DELETE FROM mvCountIssueRatingsServiceId
+    WHERE is_active = 0;
+END;

--- a/internal/database/mariadb/migrations/20260504154924_change_join_kind.down.sql
+++ b/internal/database/mariadb/migrations/20260504154924_change_join_kind.down.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP PROCEDURE IF EXISTS refresh_mvCountIssueRatingsServiceId_proc;
 
 CREATE PROCEDURE refresh_mvCountIssueRatingsServiceId_proc()

--- a/internal/database/mariadb/migrations/20260504154924_change_join_kind.up.sql
+++ b/internal/database/mariadb/migrations/20260504154924_change_join_kind.up.sql
@@ -1,0 +1,59 @@
+DROP PROCEDURE IF EXISTS refresh_mvCountIssueRatingsServiceId_proc;
+
+CREATE PROCEDURE refresh_mvCountIssueRatingsServiceId_proc()
+BEGIN
+    UPDATE mvCountIssueRatingsServiceId
+    SET is_active = 0
+    WHERE is_active = 1;
+
+    INSERT INTO mvCountIssueRatingsServiceId (
+        service_id,
+        service_ccrn,
+        critical_count,
+        high_count,
+        medium_count,
+        low_count,
+        none_count,
+        is_active
+    )
+    SELECT
+        CI.componentinstance_service_id,
+        S.service_ccrn,
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Critical'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'High'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Medium'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Low'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'None'
+            THEN CONCAT(CI.componentinstance_component_version_id, ',', I.issue_id) END),
+        1
+    FROM Issue I
+    LEFT JOIN IssueVariant IV ON IV.issuevariant_issue_id = I.issue_id
+    LEFT JOIN IssueMatch IM ON I.issue_id = IM.issuematch_issue_id
+    LEFT JOIN ComponentInstance CI
+        ON CI.componentinstance_id = IM.issuematch_component_instance_id
+       AND CI.componentinstance_deleted_at IS NULL
+    JOIN Service S ON S.service_id = CI.componentinstance_service_id
+    LEFT JOIN Remediation R
+        ON CI.componentinstance_service_id = R.remediation_service_id
+       AND I.issue_id = R.remediation_issue_id
+       AND R.remediation_deleted_at IS NULL
+    WHERE I.issue_deleted_at IS NULL
+      AND IM.issuematch_id IS NOT NULL
+      AND (R.remediation_id IS NULL OR R.remediation_expiration_date < CURDATE())
+    GROUP BY CI.componentinstance_service_id
+    ON DUPLICATE KEY UPDATE
+        service_ccrn   = VALUES(service_ccrn),
+        critical_count = VALUES(critical_count),
+        high_count     = VALUES(high_count),
+        medium_count   = VALUES(medium_count),
+        low_count      = VALUES(low_count),
+        none_count     = VALUES(none_count),
+        is_active      = 1;
+
+    DELETE FROM mvCountIssueRatingsServiceId
+    WHERE is_active = 0;
+END;

--- a/internal/database/mariadb/migrations/20260504154924_change_join_kind.up.sql
+++ b/internal/database/mariadb/migrations/20260504154924_change_join_kind.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
 DROP PROCEDURE IF EXISTS refresh_mvCountIssueRatingsServiceId_proc;
 
 CREATE PROCEDURE refresh_mvCountIssueRatingsServiceId_proc()


### PR DESCRIPTION
## Description

In this PR I've changed the kind of join from left to right because using left join in the result select we can get NULL

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

- Related Issue # (issue) https://github.com/cloudoperators/heureka/issues/1177

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🤝 Documentation pages updated
- [x] 🙅 no documentation needed
- [ ] (if applicable) generated OpenAPI docs for CRD changes
