### PR TITLE
feat(graphql): batch pre-load for GetServices, GetVulnerabilities, and GetImages queries

### DIFF
--- a/internal/api/graphql/graph/baseResolver/image.go
+++ b/internal/api/graphql/graph/baseResolver/image.go
@@ -5,12 +5,16 @@ package baseResolver
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/app"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // ImageBaseResolver retrieves a list of images based for a specific service.
@@ -65,6 +69,169 @@ func ImageBaseResolver(
 			Cursor: result.Cursor(),
 		}
 		edges = append(edges, &edge)
+	}
+
+	// Batch pre-load for nested fields
+	needVersions := lo.Contains(requestedFields, "edges.node.versions")
+	needVulnCounts := lo.Contains(requestedFields, "edges.node.vulnerabilityCounts")
+	needVulnerabilities := containsField(requestedFields, "edges.node.vulnerabilities")
+
+	if (needVersions || needVulnCounts || needVulnerabilities) && len(edges) > 0 {
+		componentIDs := make([]int64, 0, len(edges))
+		for _, edge := range edges {
+			id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+			if err != nil {
+				logrus.WithField("id", edge.Node.ID).Warn("ImageBaseResolver: failed to parse component ID for batch preload")
+				continue
+			}
+
+			componentIDs = append(componentIDs, id)
+		}
+
+		var (
+			versionsMap    map[int64][]entity.ComponentVersionResult
+			issueCountsMap map[int64]entity.IssueSeverityCounts
+			vulnsMap       map[int64][]entity.VulnerabilityResult
+			vulnCountsMap  map[int64]int
+		)
+
+		g, gCtx := errgroup.WithContext(ctx)
+
+		if needVersions {
+			g.Go(func() error {
+				var err error
+
+				versionsMap, err = app.GetVersionsByComponentIDs(gCtx, componentIDs, filter.Service)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ImageBaseResolver: batch preload versions failed")
+				}
+
+				return nil // don't fail the whole request
+			})
+		}
+
+		if needVulnCounts {
+			g.Go(func() error {
+				var err error
+
+				issueCountsMap, err = app.GetIssueCountsByComponentIDs(gCtx, componentIDs, filter.Service)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ImageBaseResolver: batch preload issue counts failed")
+				}
+
+				return nil
+			})
+		}
+
+		if needVulnerabilities {
+			g.Go(func() error {
+				var err error
+
+				vulnsMap, err = app.GetVulnerabilitiesByComponentIDs(gCtx, componentIDs)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ImageBaseResolver: batch preload vulnerabilities failed")
+				}
+
+				return nil
+			})
+			g.Go(func() error {
+				var err error
+
+				vulnCountsMap, err = app.GetVulnerabilityCountsByComponentIDs(gCtx, componentIDs)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ImageBaseResolver: batch preload vulnerability counts failed")
+				}
+
+				return nil
+			})
+		}
+
+		_ = g.Wait()
+
+		// Attach pre-loaded data to image nodes
+		for _, edge := range edges {
+			id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+			if err != nil {
+				continue
+			}
+
+			if needVersions && versionsMap != nil {
+				versions := versionsMap[id]
+				cvEdges := make([]*model.ComponentVersionEdge, 0, len(versions))
+
+				for i := range versions {
+					cv := model.NewComponentVersion(versions[i].ComponentVersion)
+					cursor := fmt.Sprintf("%d", versions[i].Id)
+					cvEdges = append(cvEdges, &model.ComponentVersionEdge{
+						Node:   &cv,
+						Cursor: &cursor,
+					})
+				}
+
+				edge.Node.Versions = &model.ComponentVersionConnection{
+					TotalCount: len(cvEdges),
+					Edges:      cvEdges,
+				}
+			}
+
+			if needVulnCounts && issueCountsMap != nil {
+				if counts, ok := issueCountsMap[id]; ok {
+					sc := model.NewSeverityCounts(&counts)
+					edge.Node.VulnerabilityCounts = &sc
+				} else {
+					sc := model.NewSeverityCounts(&entity.IssueSeverityCounts{})
+					edge.Node.VulnerabilityCounts = &sc
+				}
+			}
+
+			if needVulnerabilities && vulnsMap != nil {
+				vulns := vulnsMap[id]
+				vulnEdges := make([]*model.VulnerabilityEdge, 0, len(vulns))
+
+				for i := range vulns {
+					vr := &vulns[i]
+					vuln := model.Vulnerability{
+						ID:          fmt.Sprintf("%d", vr.IssueID),
+						Name:        &vr.PrimaryName,
+						Description: &vr.Description,
+					}
+
+					if vr.MaxSeverity != "" {
+						sevVal, err := model.SeverityValue(vr.MaxSeverity)
+						if err == nil {
+							vuln.Severity = &sevVal
+						}
+					}
+
+					if vr.SourceURL != "" {
+						vuln.SourceURL = &vr.SourceURL
+					}
+
+					if vr.EarliestRemediationDate != nil {
+						dateStr := vr.EarliestRemediationDate.Format(time.RFC3339)
+						vuln.EarliestTargetRemediationDate = &dateStr
+					}
+
+					vulnEdges = append(vulnEdges, &model.VulnerabilityEdge{
+						Node:   &vuln,
+						Cursor: lo.ToPtr(fmt.Sprintf("%d", vr.IssueID)),
+					})
+				}
+
+				totalVulnCount := len(vulns)
+
+				if vulnCountsMap != nil {
+					if cnt, ok := vulnCountsMap[id]; ok {
+						totalVulnCount = cnt
+					}
+				}
+
+				edge.Node.Vulnerabilities = &model.VulnerabilityConnection{
+					TotalCount: totalVulnCount,
+					Edges:      vulnEdges,
+				}
+			}
+		}
 	}
 
 	totalCount := 0

--- a/internal/api/graphql/graph/baseResolver/service.go
+++ b/internal/api/graphql/graph/baseResolver/service.go
@@ -5,12 +5,15 @@ package baseResolver
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/app"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 func SingleServiceBaseResolver(
@@ -189,6 +192,129 @@ func ServiceBaseResolver(
 		}
 
 		edges = append(edges, &edge)
+	}
+
+	// Batch pre-load for nested fields
+	needOwners := lo.Contains(requestedFields, "edges.node.owners")
+	needSupportGroups := lo.Contains(requestedFields, "edges.node.supportGroups")
+	needIssueCounts := lo.Contains(requestedFields, "edges.node.issueCounts")
+
+	if (needOwners || needSupportGroups || needIssueCounts) && len(edges) > 0 {
+		serviceIDs := make([]int64, 0, len(edges))
+		for _, edge := range edges {
+			id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+			if err != nil {
+				logrus.WithField("id", edge.Node.ID).Warn("ServiceBaseResolver: failed to parse service ID for batch preload")
+				continue
+			}
+
+			serviceIDs = append(serviceIDs, id)
+		}
+
+		var (
+			ownersMap       map[int64][]entity.User
+			supportGroupMap map[int64][]entity.SupportGroup
+			issueCountsMap  map[int64]entity.IssueSeverityCounts
+		)
+
+		g, gCtx := errgroup.WithContext(ctx)
+
+		if needOwners {
+			g.Go(func() error {
+				var err error
+
+				ownersMap, err = app.ListOwnersByServiceIDs(gCtx, serviceIDs)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ServiceBaseResolver: batch preload owners failed")
+				}
+
+				return nil // don't fail the whole request
+			})
+		}
+
+		if needSupportGroups {
+			g.Go(func() error {
+				var err error
+
+				supportGroupMap, err = app.ListSupportGroupsByServiceIDs(gCtx, serviceIDs)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ServiceBaseResolver: batch preload support groups failed")
+				}
+
+				return nil
+			})
+		}
+
+		if needIssueCounts {
+			g.Go(func() error {
+				var err error
+
+				issueCountsMap, err = app.ListIssueCountsByServiceIDs(gCtx, serviceIDs)
+				if err != nil {
+					logrus.WithField("error", err).Warn("ServiceBaseResolver: batch preload issue counts failed")
+				}
+
+				return nil
+			})
+		}
+
+		_ = g.Wait()
+
+		// Attach pre-loaded data to service nodes
+		for _, edge := range edges {
+			id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+			if err != nil {
+				continue
+			}
+
+			if needOwners && ownersMap != nil {
+				users := ownersMap[id]
+				userEdges := make([]*model.UserEdge, 0, len(users))
+
+				for i := range users {
+					u := model.NewUser(&users[i])
+					cursor := fmt.Sprintf("%d", users[i].Id)
+					userEdges = append(userEdges, &model.UserEdge{
+						Node:   &u,
+						Cursor: &cursor,
+					})
+				}
+
+				edge.Node.Owners = &model.UserConnection{
+					TotalCount: len(userEdges),
+					Edges:      userEdges,
+				}
+			}
+
+			if needSupportGroups && supportGroupMap != nil {
+				sgs := supportGroupMap[id]
+
+				sgEdges := make([]*model.SupportGroupEdge, 0, len(sgs))
+				for i := range sgs {
+					sg := model.NewSupportGroup(&sgs[i])
+					cursor := fmt.Sprintf("%d", sgs[i].Id)
+					sgEdges = append(sgEdges, &model.SupportGroupEdge{
+						Node:   &sg,
+						Cursor: &cursor,
+					})
+				}
+
+				edge.Node.SupportGroups = &model.SupportGroupConnection{
+					TotalCount: len(sgEdges),
+					Edges:      sgEdges,
+				}
+			}
+
+			if needIssueCounts && issueCountsMap != nil {
+				if counts, ok := issueCountsMap[id]; ok {
+					sc := model.NewSeverityCounts(&counts)
+					edge.Node.IssueCounts = &sc
+				} else {
+					sc := model.NewSeverityCounts(&entity.IssueSeverityCounts{})
+					edge.Node.IssueCounts = &sc
+				}
+			}
+		}
 	}
 
 	tc := 0

--- a/internal/api/graphql/graph/baseResolver/vulnerability.go
+++ b/internal/api/graphql/graph/baseResolver/vulnerability.go
@@ -5,6 +5,9 @@ package baseResolver
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/app"
@@ -12,6 +15,7 @@ import (
 	"github.com/cloudoperators/heureka/internal/util"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // VulnerabilityBaseResolver retrieves a list of vulnerabilities based on the provided filter and
@@ -38,14 +42,23 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		ServiceCCRN:      filter.Service,
 		Type:             []*string{new(entity.IssueTypeVulnerability.String())},
 		Search:           filter.Search,
-		HasIssueMatches:  true,
 		Status:           model.NewIssueStatus(filter.Status),
-		IssueMatchStatus: []*string{new(entity.IssueMatchStatusValuesNew.String())},
 		IssueMatchSeverity: lo.Map(
 			filter.Severity,
 			func(item *model.SeverityValues, _ int) *string { return new(item.String()) },
 		),
 		PrimaryName: filter.Name,
+	}
+
+	// Use materialized view when no filters require live IssueMatch data.
+	// The MV pre-computes "issues with at least one new IssueMatch" so we don't
+	// need the expensive RIGHT JOIN on the 10M+ row IssueMatch table.
+	needsLiveIssueMatch := len(f.IssueMatchSeverity) > 0 || len(filter.SupportGroup) > 0 || len(filter.Service) > 0
+	if !needsLiveIssueMatch {
+		f.UseMvVulnerabilityList = true
+	} else {
+		f.HasIssueMatches = true
+		f.IssueMatchStatus = []*string{new(entity.IssueMatchStatusValuesNew.String())}
 	}
 
 	if parent != nil {
@@ -98,6 +111,21 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		edges = append(edges, &edge)
 	}
 
+	// Batch pre-load child fields if requested and there are results
+	if len(edges) > 0 {
+		issueIDs := make([]int64, 0, len(edges))
+		for _, edge := range edges {
+			id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+			if err == nil {
+				issueIDs = append(issueIDs, id)
+			}
+		}
+
+		if len(issueIDs) > 0 {
+			batchPreloadVulnerabilities(ctx, app, requestedFields, issueIDs, edges)
+		}
+	}
+
 	totalCount := 0
 	if issues.TotalCount != nil {
 		totalCount = int(*issues.TotalCount)
@@ -133,4 +161,185 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 	}
 
 	return &connection, nil
+}
+
+// batchPreloadVulnerabilities runs concurrent batch queries to pre-load child fields
+// for the Vulnerability list, reducing the N+1 query problem.
+func batchPreloadVulnerabilities(
+	ctx context.Context,
+	app app.Heureka,
+	requestedFields []string,
+	issueIDs []int64,
+	edges []*model.VulnerabilityEdge,
+) {
+	// Build a lookup map from issue ID to vulnerability node
+	idToVuln := make(map[int64]*model.Vulnerability, len(edges))
+	for _, edge := range edges {
+		id, err := strconv.ParseInt(edge.Node.ID, 10, 64)
+		if err == nil {
+			idToVuln[id] = edge.Node
+		}
+	}
+
+	// Determine which fields need batch loading
+	needSeverity := containsField(requestedFields, "edges.node.severity")
+	needSourceURL := containsField(requestedFields, "edges.node.sourceUrl")
+	needRemediation := containsField(requestedFields, "edges.node.earliestTargetRemediationDate")
+	needServices := containsField(requestedFields, "edges.node.services")
+	needSupportGroups := containsField(requestedFields, "edges.node.supportGroups")
+
+	if !needSeverity && !needSourceURL && !needRemediation && !needServices && !needSupportGroups {
+		return
+	}
+
+	// Results
+	var severityMap map[int64]string
+
+	var sourceURLMap map[int64]string
+
+	var remediationMap map[int64]time.Time
+
+	var servicesMap map[int64][]entity.ServiceResult
+
+	var supportGroupsMap map[int64][]entity.SupportGroupResult
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// Use a single MV-backed query for severity, sourceURL, and remediation date
+	// instead of 3 separate aggregate queries over the IssueMatch table.
+	needAggregates := needSeverity || needSourceURL || needRemediation
+	if needAggregates {
+		g.Go(func() error {
+			aggregates, err := app.GetVulnerabilityAggregatesByIssueIDs(gCtx, issueIDs)
+			if err != nil {
+				return err
+			}
+			// Decompose aggregates into the individual maps for downstream consumption
+			if needSeverity {
+				severityMap = make(map[int64]string, len(aggregates))
+				for id, agg := range aggregates {
+					if agg.MaxSeverity != "" {
+						severityMap[id] = agg.MaxSeverity
+					}
+				}
+			}
+
+			if needSourceURL {
+				sourceURLMap = make(map[int64]string, len(aggregates))
+				for id, agg := range aggregates {
+					if agg.SourceURL != "" {
+						sourceURLMap[id] = agg.SourceURL
+					}
+				}
+			}
+
+			if needRemediation {
+				remediationMap = make(map[int64]time.Time, len(aggregates))
+				for id, agg := range aggregates {
+					if agg.EarliestRemediationDate != nil {
+						remediationMap[id] = *agg.EarliestRemediationDate
+					}
+				}
+			}
+
+			return nil
+		})
+	}
+
+	if needServices {
+		g.Go(func() error {
+			var err error
+
+			servicesMap, err = app.GetServicesByIssueIDs(gCtx, issueIDs)
+
+			return err
+		})
+	}
+
+	if needSupportGroups {
+		g.Go(func() error {
+			var err error
+
+			supportGroupsMap, err = app.GetSupportGroupsByIssueIDs(gCtx, issueIDs)
+
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		logrus.WithError(err).Warn("VulnerabilityBaseResolver: batch pre-load partially failed, falling through to per-item resolvers")
+		return
+	}
+
+	// Attach pre-loaded data to vulnerability nodes
+	for issueID, vuln := range idToVuln {
+		if needSeverity && severityMap != nil {
+			if sevStr, ok := severityMap[issueID]; ok {
+				sevVal, err := model.SeverityValue(sevStr)
+				if err == nil {
+					vuln.Severity = &sevVal
+				}
+			}
+		}
+
+		if needSourceURL && sourceURLMap != nil {
+			if url, ok := sourceURLMap[issueID]; ok {
+				vuln.SourceURL = &url
+			}
+		}
+
+		if needRemediation && remediationMap != nil {
+			if date, ok := remediationMap[issueID]; ok {
+				dateStr := date.Format(time.RFC3339)
+				vuln.EarliestTargetRemediationDate = &dateStr
+			}
+		}
+
+		if needServices && servicesMap != nil {
+			services := servicesMap[issueID]
+
+			serviceEdges := make([]*model.ServiceEdge, 0, len(services))
+			for _, sr := range services {
+				svc := model.NewService(sr.Service)
+				serviceEdges = append(serviceEdges, &model.ServiceEdge{
+					Node:   &svc,
+					Cursor: lo.ToPtr(fmt.Sprintf("%d", sr.Id)),
+				})
+			}
+
+			vuln.Services = &model.ServiceConnection{
+				TotalCount: len(services),
+				Edges:      serviceEdges,
+			}
+		}
+
+		if needSupportGroups && supportGroupsMap != nil {
+			groups := supportGroupsMap[issueID]
+
+			sgEdges := make([]*model.SupportGroupEdge, 0, len(groups))
+			for _, sgr := range groups {
+				sg := model.NewSupportGroup(sgr.SupportGroup)
+				sgEdges = append(sgEdges, &model.SupportGroupEdge{
+					Node:   &sg,
+					Cursor: lo.ToPtr(fmt.Sprintf("%d", sgr.Id)),
+				})
+			}
+
+			vuln.SupportGroups = &model.SupportGroupConnection{
+				TotalCount: len(groups),
+				Edges:      sgEdges,
+			}
+		}
+	}
+}
+
+// containsField checks if any of the requested fields match or start with the given prefix.
+func containsField(requestedFields []string, field string) bool {
+	for _, rf := range requestedFields {
+		if rf == field || len(rf) > len(field) && rf[:len(field)+1] == field+"." {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/api/graphql/graph/baseResolver/vulnerability.go
+++ b/internal/api/graphql/graph/baseResolver/vulnerability.go
@@ -43,22 +43,7 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		Type:             []*string{new(entity.IssueTypeVulnerability.String())},
 		Search:           filter.Search,
 		Status:           model.NewIssueStatus(filter.Status),
-		IssueMatchSeverity: lo.Map(
-			filter.Severity,
-			func(item *model.SeverityValues, _ int) *string { return new(item.String()) },
-		),
-		PrimaryName: filter.Name,
-	}
-
-	// Use materialized view when no filters require live IssueMatch data.
-	// The MV pre-computes "issues with at least one new IssueMatch" so we don't
-	// need the expensive RIGHT JOIN on the 10M+ row IssueMatch table.
-	needsLiveIssueMatch := len(f.IssueMatchSeverity) > 0 || len(filter.SupportGroup) > 0 || len(filter.Service) > 0
-	if !needsLiveIssueMatch {
-		f.UseMvVulnerabilityList = true
-	} else {
-		f.HasIssueMatches = true
-		f.IssueMatchStatus = []*string{new(entity.IssueMatchStatusValuesNew.String())}
+		PrimaryName:      filter.Name,
 	}
 
 	if parent != nil {
@@ -81,6 +66,25 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		case model.ImageVersionNodeName:
 			f.ComponentVersionId = []*int64{pid}
 		}
+
+		// When resolving vulnerabilities for a specific parent (Image/ImageVersion),
+		// use the live IssueMatch join path since the ComponentVersionIssue join
+		// already scopes to the relevant issues.
+		f.HasIssueMatches = true
+		f.IssueMatchStatus = []*string{new(entity.IssueMatchStatusValuesNew.String())}
+		f.IssueMatchSeverity = lo.Map(
+			filter.Severity,
+			func(item *model.SeverityValues, _ int) *string { return new(item.String()) },
+		)
+	} else {
+		// Top-level vulnerability list: use the materialized view for performance.
+		// The MV pre-computes "issues with at least one new IssueMatch" so we avoid
+		// the expensive RIGHT JOIN on the 10M+ row IssueMatch table.
+		f.UseMvVulnerabilityList = true
+		f.MvSeverity = lo.Map(
+			filter.Severity,
+			func(item *model.SeverityValues, _ int) *string { return new(item.String()) },
+		)
 	}
 
 	opt := GetIssueListOptions(requestedFields)

--- a/internal/api/graphql/graph/resolver/image.go
+++ b/internal/api/graphql/graph/resolver/image.go
@@ -19,6 +19,21 @@ import (
 // SPDX-License-Identifier: Apache-2.0
 
 func (r *imageResolver) Versions(ctx context.Context, obj *model.Image, first *int, after *string) (*model.ComponentVersionConnection, error) {
+	// Return pre-loaded data if available AND no pagination cursor is provided
+	if obj.Versions != nil && after == nil {
+		// If first is specified, truncate the pre-loaded results
+		if first != nil && len(obj.Versions.Edges) > *first {
+			truncated := &model.ComponentVersionConnection{
+				TotalCount: obj.Versions.TotalCount,
+				Edges:      obj.Versions.Edges[:*first],
+			}
+
+			return truncated, nil
+		}
+
+		return obj.Versions, nil
+	}
+
 	rootCtx := baseResolver.GetRoot(graphql.GetFieldContext(ctx))
 	imageFilter := rootCtx.Args["filter"].(*model.ImageFilter)
 	filter := &model.ComponentVersionFilter{
@@ -44,6 +59,11 @@ func (r *imageResolver) Versions(ctx context.Context, obj *model.Image, first *i
 }
 
 func (r *imageResolver) VulnerabilityCounts(ctx context.Context, obj *model.Image) (*model.SeverityCounts, error) {
+	// Return pre-loaded data if available
+	if obj.VulnerabilityCounts != nil {
+		return obj.VulnerabilityCounts, nil
+	}
+
 	rootCtx := baseResolver.GetRoot(graphql.GetFieldContext(ctx))
 	imageFilter := rootCtx.Args["filter"].(*model.ImageFilter)
 	filter := &model.ComponentFilter{
@@ -58,6 +78,23 @@ func (r *imageResolver) VulnerabilityCounts(ctx context.Context, obj *model.Imag
 }
 
 func (r *imageResolver) Vulnerabilities(ctx context.Context, obj *model.Image, first *int, after *string, filter *model.VulnerabilityFilter) (*model.VulnerabilityConnection, error) {
+	// Use pre-loaded data only when:
+	// 1. Data was pre-loaded (obj.Vulnerabilities != nil)
+	// 2. No pagination cursor (after == nil) — cursor means user is paginating
+	// 3. No user-supplied filter — filter would narrow results beyond what was pre-loaded
+	hasUserFilter := filter != nil && (len(filter.Severity) > 0 || len(filter.Name) > 0 || filter.Status != nil || len(filter.Search) > 0)
+	if obj.Vulnerabilities != nil && after == nil && !hasUserFilter {
+		if first != nil && len(obj.Vulnerabilities.Edges) > *first {
+			return &model.VulnerabilityConnection{
+				TotalCount: obj.Vulnerabilities.TotalCount,
+				Edges:      obj.Vulnerabilities.Edges[:*first],
+				PageInfo:   obj.Vulnerabilities.PageInfo,
+			}, nil
+		}
+
+		return obj.Vulnerabilities, nil
+	}
+
 	rootCtx := baseResolver.GetRoot(graphql.GetFieldContext(ctx))
 	imageFilter := rootCtx.Args["filter"].(*model.ImageFilter)
 

--- a/internal/api/graphql/graph/resolver/service.go
+++ b/internal/api/graphql/graph/resolver/service.go
@@ -17,6 +17,12 @@ import (
 // SPDX-License-Identifier: Apache-2.0
 
 func (r *serviceResolver) Owners(ctx context.Context, obj *model.Service, filter *model.UserFilter, first *int, after *string) (*model.UserConnection, error) {
+	// Return pre-loaded data if available (batch pre-load from ServiceBaseResolver)
+	// Only use pre-loaded data when no filter/pagination is requested.
+	if obj.Owners != nil && filter == nil && first == nil && after == nil {
+		return obj.Owners, nil
+	}
+
 	return baseResolver.UserBaseResolver(r.App, ctx, filter, first, after,
 		&model.NodeParent{
 			Parent:     obj,
@@ -25,6 +31,12 @@ func (r *serviceResolver) Owners(ctx context.Context, obj *model.Service, filter
 }
 
 func (r *serviceResolver) SupportGroups(ctx context.Context, obj *model.Service, filter *model.SupportGroupFilter, first *int, after *string, orderBy []*model.SupportGroupOrderBy) (*model.SupportGroupConnection, error) {
+	// Return pre-loaded data if available (batch pre-load from ServiceBaseResolver)
+	// Only use pre-loaded data when no filter/pagination/ordering is requested.
+	if obj.SupportGroups != nil && filter == nil && first == nil && after == nil && len(orderBy) == 0 {
+		return obj.SupportGroups, nil
+	}
+
 	return baseResolver.SupportGroupBaseResolver(r.App, ctx, filter, first, after, orderBy,
 		&model.NodeParent{
 			Parent:     obj,
@@ -79,6 +91,13 @@ func (r *serviceResolver) Remediations(ctx context.Context, obj *model.Service, 
 }
 
 func (r *serviceResolver) IssueCounts(ctx context.Context, obj *model.Service, filter *model.IssueFilter) (*model.SeverityCounts, error) {
+	// Return pre-loaded data if available (batch pre-load from ServiceBaseResolver)
+	// Only use pre-loaded data when no filter is provided, since the batch pre-load
+	// computes unfiltered counts per service.
+	if obj.IssueCounts != nil && filter == nil {
+		return obj.IssueCounts, nil
+	}
+
 	return baseResolver.IssueCountsBaseResolver(r.App, ctx, filter, &model.NodeParent{
 		Parent:     obj,
 		ParentName: model.ServiceNodeName,

--- a/internal/api/graphql/graph/resolver/vulnerability.go
+++ b/internal/api/graphql/graph/resolver/vulnerability.go
@@ -18,6 +18,11 @@ import (
 // SPDX-License-Identifier: Apache-2.0
 
 func (r *vulnerabilityResolver) Severity(ctx context.Context, obj *model.Vulnerability) (*model.SeverityValues, error) {
+	// Return pre-loaded data if available
+	if obj.Severity != nil {
+		return obj.Severity, nil
+	}
+
 	first := new(1)
 	order := []*model.IssueMatchOrderBy{
 		{
@@ -50,6 +55,11 @@ func (r *vulnerabilityResolver) Severity(ctx context.Context, obj *model.Vulnera
 }
 
 func (r *vulnerabilityResolver) SourceURL(ctx context.Context, obj *model.Vulnerability) (*string, error) {
+	// Return pre-loaded data if available
+	if obj.SourceURL != nil {
+		return obj.SourceURL, nil
+	}
+
 	first := new(1)
 
 	iv, err := baseResolver.IssueVariantBaseResolver(r.App, ctx, nil, first, nil, &model.NodeParent{
@@ -68,6 +78,11 @@ func (r *vulnerabilityResolver) SourceURL(ctx context.Context, obj *model.Vulner
 }
 
 func (r *vulnerabilityResolver) EarliestTargetRemediationDate(ctx context.Context, obj *model.Vulnerability) (*string, error) {
+	// Return pre-loaded data if available
+	if obj.EarliestTargetRemediationDate != nil {
+		return obj.EarliestTargetRemediationDate, nil
+	}
+
 	first := new(1)
 	order := []*model.IssueMatchOrderBy{
 		{
@@ -100,6 +115,21 @@ func (r *vulnerabilityResolver) EarliestTargetRemediationDate(ctx context.Contex
 }
 
 func (r *vulnerabilityResolver) Services(ctx context.Context, obj *model.Vulnerability, first *int, after *string) (*model.ServiceConnection, error) {
+	// Return pre-loaded data if available AND no pagination cursor is provided
+	if obj.Services != nil && after == nil {
+		// If first is specified, truncate the pre-loaded results
+		if first != nil && len(obj.Services.Edges) > *first {
+			truncated := &model.ServiceConnection{
+				TotalCount: obj.Services.TotalCount,
+				Edges:      obj.Services.Edges[:*first],
+			}
+
+			return truncated, nil
+		}
+
+		return obj.Services, nil
+	}
+
 	order := []*model.ServiceOrderBy{
 		{
 			By:        lo.ToPtr(model.ServiceOrderByFieldCcrn),
@@ -114,6 +144,21 @@ func (r *vulnerabilityResolver) Services(ctx context.Context, obj *model.Vulnera
 }
 
 func (r *vulnerabilityResolver) SupportGroups(ctx context.Context, obj *model.Vulnerability, first *int, after *string) (*model.SupportGroupConnection, error) {
+	// Return pre-loaded data if available AND no pagination cursor is provided
+	if obj.SupportGroups != nil && after == nil {
+		// If first is specified, truncate the pre-loaded results
+		if first != nil && len(obj.SupportGroups.Edges) > *first {
+			truncated := &model.SupportGroupConnection{
+				TotalCount: obj.SupportGroups.TotalCount,
+				Edges:      obj.SupportGroups.Edges[:*first],
+			}
+
+			return truncated, nil
+		}
+
+		return obj.SupportGroups, nil
+	}
+
 	order := []*model.SupportGroupOrderBy{
 		{
 			By:        lo.ToPtr(model.SupportGroupOrderByFieldCcrn),

--- a/internal/api/graphql/middleware/query_counter.go
+++ b/internal/api/graphql/middleware/query_counter.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// QueryCounter is a Gin middleware that initializes a per-request DB query counter
+// and logs the total count at request completion.
+func QueryCounter() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := querycounter.Init(c.Request.Context())
+		c.Request = c.Request.WithContext(ctx)
+
+		c.Next()
+
+		count := querycounter.GetQueryCount(c.Request.Context())
+		logrus.WithFields(logrus.Fields{
+			"db_query_count": count,
+			"method":         c.Request.Method,
+			"path":           c.Request.URL.Path,
+		}).Debug("Request completed")
+	}
+}

--- a/internal/api/graphql/middleware/query_counter_test.go
+++ b/internal/api/graphql/middleware/query_counter_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+	"github.com/gin-gonic/gin"
+)
+
+func TestQueryCounter_InitializesCounter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var capturedCount int
+
+	router := gin.New()
+	router.Use(QueryCounter())
+	router.POST("/query", func(c *gin.Context) {
+		// Simulate DB queries
+		querycounter.Increment(c.Request.Context())
+		querycounter.Increment(c.Request.Context())
+		querycounter.Increment(c.Request.Context())
+		capturedCount = querycounter.GetQueryCount(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/query", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if capturedCount != 3 {
+		t.Errorf("expected query count 3, got %d", capturedCount)
+	}
+}
+
+func TestQueryCounter_IsolatesRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	counts := make([]int, 2)
+	callIndex := 0
+
+	router := gin.New()
+	router.Use(QueryCounter())
+	router.POST("/query", func(c *gin.Context) {
+		idx := callIndex
+		callIndex++
+		// First request: 5 queries, second: 2 queries
+		n := 5
+		if idx == 1 {
+			n = 2
+		}
+
+		for range n {
+			querycounter.Increment(c.Request.Context())
+		}
+
+		counts[idx] = querycounter.GetQueryCount(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	req1 := httptest.NewRequest(http.MethodPost, "/query", nil)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/query", nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+
+	if counts[0] != 5 {
+		t.Errorf("first request: expected 5, got %d", counts[0])
+	}
+
+	if counts[1] != 2 {
+		t.Errorf("second request: expected 2, got %d", counts[1])
+	}
+}

--- a/internal/api/graphql/server.go
+++ b/internal/api/graphql/server.go
@@ -50,6 +50,7 @@ func NewGraphQLAPI(a app.Heureka, cfg util.Config) *GraphQLAPI {
 func (g *GraphQLAPI) CreateEndpoints(router *gin.Engine) {
 	router.Use(g.rateLimiter.Middleware())
 	router.Use(g.auth.Middleware())
+	router.Use(gqlmiddleware.QueryCounter())
 	router.GET("/playground", g.playgroundHandler())
 	router.POST("/query", g.graphqlHandler())
 }

--- a/internal/app/component/component_handler_batch.go
+++ b/internal/app/component/component_handler_batch.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudoperators/heureka/internal/cache"
+	"github.com/cloudoperators/heureka/internal/entity"
+)
+
+var (
+	CacheTtlGetVersionsByComponentIDs            = 12 * time.Hour
+	CacheTtlGetIssueCountsByComponentIDs         = 12 * time.Hour
+	CacheTtlGetVulnerabilitiesByComponentIDs     = 12 * time.Hour
+	CacheTtlGetVulnerabilityCountsByComponentIDs = 12 * time.Hour
+)
+
+func (cs *componentHandler) GetVersionsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64][]entity.ComponentVersionResult, error) {
+	return cache.CallCached[map[int64][]entity.ComponentVersionResult](
+		cs.cache,
+		CacheTtlGetVersionsByComponentIDs,
+		"GetVersionsByComponentIDs",
+		cache.WrapContext2(ctx, cs.database.GetVersionsByComponentIDs),
+		componentIDs,
+		serviceCCRN,
+	)
+}
+
+func (cs *componentHandler) GetIssueCountsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64]entity.IssueSeverityCounts, error) {
+	return cache.CallCached[map[int64]entity.IssueSeverityCounts](
+		cs.cache,
+		CacheTtlGetIssueCountsByComponentIDs,
+		"GetIssueCountsByComponentIDs",
+		cache.WrapContext2(ctx, cs.database.GetIssueCountsByComponentIDs),
+		componentIDs,
+		serviceCCRN,
+	)
+}
+
+func (cs *componentHandler) GetVulnerabilitiesByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64][]entity.VulnerabilityResult, error) {
+	return cache.CallCached[map[int64][]entity.VulnerabilityResult](
+		cs.cache,
+		CacheTtlGetVulnerabilitiesByComponentIDs,
+		"GetVulnerabilitiesByComponentIDs",
+		cache.WrapContext1(ctx, cs.database.GetVulnerabilitiesByComponentIDs),
+		componentIDs,
+	)
+}
+
+func (cs *componentHandler) GetVulnerabilityCountsByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64]int, error) {
+	return cache.CallCached[map[int64]int](
+		cs.cache,
+		CacheTtlGetVulnerabilityCountsByComponentIDs,
+		"GetVulnerabilityCountsByComponentIDs",
+		cache.WrapContext1(ctx, cs.database.GetVulnerabilityCountsByComponentIDs),
+		componentIDs,
+	)
+}

--- a/internal/app/component/component_handler_interface.go
+++ b/internal/app/component/component_handler_interface.go
@@ -20,4 +20,8 @@ type ComponentHandler interface {
 	DeleteComponent(context.Context, int64) error
 	ListComponentCcrns(context.Context, *entity.ComponentFilter, *entity.ListOptions) ([]string, error)
 	GetComponentVulnerabilityCounts(context.Context, *entity.ComponentFilter) ([]entity.IssueSeverityCounts, error)
+	GetVersionsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64][]entity.ComponentVersionResult, error)
+	GetIssueCountsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64]entity.IssueSeverityCounts, error)
+	GetVulnerabilitiesByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64][]entity.VulnerabilityResult, error)
+	GetVulnerabilityCountsByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64]int, error)
 }

--- a/internal/app/issue/issue_handler_batch.go
+++ b/internal/app/issue/issue_handler_batch.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package issue
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudoperators/heureka/internal/cache"
+	"github.com/cloudoperators/heureka/internal/entity"
+)
+
+var (
+	CacheTtlGetMaxSeverityByIssueIDs             = 12 * time.Hour
+	CacheTtlGetEarliestRemediationByIssueIDs     = 12 * time.Hour
+	CacheTtlGetSourceURLsByIssueIDs              = 12 * time.Hour
+	CacheTtlGetServicesByIssueIDs                = 12 * time.Hour
+	CacheTtlGetSupportGroupsByIssueIDs           = 12 * time.Hour
+	CacheTtlGetVulnerabilityAggregatesByIssueIDs = 12 * time.Hour
+)
+
+func (is *issueHandler) GetMaxSeverityByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]string, error) {
+	return cache.CallCached[map[int64]string](
+		is.cache,
+		CacheTtlGetMaxSeverityByIssueIDs,
+		"GetMaxSeverityByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetMaxSeverityByIssueIDs),
+		issueIDs,
+	)
+}
+
+func (is *issueHandler) GetEarliestRemediationByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]time.Time, error) {
+	return cache.CallCached[map[int64]time.Time](
+		is.cache,
+		CacheTtlGetEarliestRemediationByIssueIDs,
+		"GetEarliestRemediationByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetEarliestRemediationByIssueIDs),
+		issueIDs,
+	)
+}
+
+func (is *issueHandler) GetSourceURLsByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]string, error) {
+	return cache.CallCached[map[int64]string](
+		is.cache,
+		CacheTtlGetSourceURLsByIssueIDs,
+		"GetSourceURLsByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetSourceURLsByIssueIDs),
+		issueIDs,
+	)
+}
+
+func (is *issueHandler) GetServicesByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64][]entity.ServiceResult, error) {
+	return cache.CallCached[map[int64][]entity.ServiceResult](
+		is.cache,
+		CacheTtlGetServicesByIssueIDs,
+		"GetServicesByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetServicesByIssueIDs),
+		issueIDs,
+	)
+}
+
+func (is *issueHandler) GetSupportGroupsByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64][]entity.SupportGroupResult, error) {
+	return cache.CallCached[map[int64][]entity.SupportGroupResult](
+		is.cache,
+		CacheTtlGetSupportGroupsByIssueIDs,
+		"GetSupportGroupsByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetSupportGroupsByIssueIDs),
+		issueIDs,
+	)
+}
+
+func (is *issueHandler) GetVulnerabilityAggregatesByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]entity.VulnerabilityAggregate, error) {
+	return cache.CallCached[map[int64]entity.VulnerabilityAggregate](
+		is.cache,
+		CacheTtlGetVulnerabilityAggregatesByIssueIDs,
+		"GetVulnerabilityAggregatesByIssueIDs",
+		cache.WrapContext1(ctx, is.database.GetVulnerabilityAggregatesByIssueIDs),
+		issueIDs,
+	)
+}

--- a/internal/app/issue/issue_handler_interface.go
+++ b/internal/app/issue/issue_handler_interface.go
@@ -5,6 +5,7 @@ package issue
 
 import (
 	"context"
+	"time"
 
 	"github.com/cloudoperators/heureka/internal/entity"
 )
@@ -19,4 +20,12 @@ type IssueHandler interface {
 	RemoveComponentVersionFromIssue(context.Context, int64, int64) (*entity.Issue, error)
 	ListIssueNames(context.Context, *entity.IssueFilter, *entity.ListOptions) ([]string, error)
 	GetIssueSeverityCounts(context.Context, *entity.IssueFilter) (*entity.IssueSeverityCounts, error)
+
+	// Batch pre-load methods for GetVulnerabilities query optimization
+	GetMaxSeverityByIssueIDs(context.Context, []int64) (map[int64]string, error)
+	GetEarliestRemediationByIssueIDs(context.Context, []int64) (map[int64]time.Time, error)
+	GetSourceURLsByIssueIDs(context.Context, []int64) (map[int64]string, error)
+	GetServicesByIssueIDs(context.Context, []int64) (map[int64][]entity.ServiceResult, error)
+	GetSupportGroupsByIssueIDs(context.Context, []int64) (map[int64][]entity.SupportGroupResult, error)
+	GetVulnerabilityAggregatesByIssueIDs(context.Context, []int64) (map[int64]entity.VulnerabilityAggregate, error)
 }

--- a/internal/app/service/service_handler.go
+++ b/internal/app/service/service_handler.go
@@ -20,11 +20,14 @@ import (
 )
 
 var (
-	CacheTtlGetServiceAttrs             = 12 * time.Hour
-	CacheTtlGetServicesWithAggregations = 12 * time.Hour
-	CacheTtlGetServices                 = 12 * time.Hour
-	CacheTtlGetAllSericeCursors         = 12 * time.Hour
-	CacheTtlCountServices               = 12 * time.Hour
+	CacheTtlGetServiceAttrs              = 12 * time.Hour
+	CacheTtlGetServicesWithAggregations  = 12 * time.Hour
+	CacheTtlGetServices                  = 12 * time.Hour
+	CacheTtlGetAllSericeCursors          = 12 * time.Hour
+	CacheTtlCountServices                = 12 * time.Hour
+	CacheTtlGetOwnersByServiceIDs        = 12 * time.Hour
+	CacheTtlGetSupportGroupsByServiceIDs = 12 * time.Hour
+	CacheTtlGetIssueCountsByServiceIDs   = 12 * time.Hour
 )
 
 type serviceHandler struct {
@@ -541,4 +544,76 @@ func (s *serviceHandler) ListServiceRegions(
 	)
 
 	return serviceRegions, nil
+}
+
+func (s *serviceHandler) ListOwnersByServiceIDs(
+	ctx context.Context,
+	serviceIDs []int64,
+) (map[int64][]entity.User, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "ListOwnersByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	owners, err := cache.CallCached[map[int64][]entity.User](
+		s.cache,
+		CacheTtlGetOwnersByServiceIDs,
+		"GetOwnersByServiceIDs",
+		cache.WrapContext1(ctx, s.database.GetOwnersByServiceIDs),
+		serviceIDs,
+	)
+	if err != nil {
+		l.Error(err)
+		return nil, NewServiceHandlerError("Internal error while retrieving owners by service IDs.")
+	}
+
+	return owners, nil
+}
+
+func (s *serviceHandler) ListSupportGroupsByServiceIDs(
+	ctx context.Context,
+	serviceIDs []int64,
+) (map[int64][]entity.SupportGroup, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "ListSupportGroupsByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	supportGroups, err := cache.CallCached[map[int64][]entity.SupportGroup](
+		s.cache,
+		CacheTtlGetSupportGroupsByServiceIDs,
+		"GetSupportGroupsByServiceIDs",
+		cache.WrapContext1(ctx, s.database.GetSupportGroupsByServiceIDs),
+		serviceIDs,
+	)
+	if err != nil {
+		l.Error(err)
+		return nil, NewServiceHandlerError("Internal error while retrieving support groups by service IDs.")
+	}
+
+	return supportGroups, nil
+}
+
+func (s *serviceHandler) ListIssueCountsByServiceIDs(
+	ctx context.Context,
+	serviceIDs []int64,
+) (map[int64]entity.IssueSeverityCounts, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "ListIssueCountsByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	issueCounts, err := cache.CallCached[map[int64]entity.IssueSeverityCounts](
+		s.cache,
+		CacheTtlGetIssueCountsByServiceIDs,
+		"GetIssueCountsByServiceIDs",
+		cache.WrapContext1(ctx, s.database.GetIssueCountsByServiceIDs),
+		serviceIDs,
+	)
+	if err != nil {
+		l.Error(err)
+		return nil, NewServiceHandlerError("Internal error while retrieving issue counts by service IDs.")
+	}
+
+	return issueCounts, nil
 }

--- a/internal/app/service/service_handler_interface.go
+++ b/internal/app/service/service_handler_interface.go
@@ -26,4 +26,7 @@ type ServiceHandler interface {
 	ListServiceRegions(ctx context.Context, filter *entity.ServiceFilter, options *entity.ListOptions) ([]string, error)
 	AddIssueRepositoryToService(context.Context, int64, int64, int64) (*entity.Service, error)
 	RemoveIssueRepositoryFromService(context.Context, int64, int64) (*entity.Service, error)
+	ListOwnersByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64][]entity.User, error)
+	ListSupportGroupsByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64][]entity.SupportGroup, error)
+	ListIssueCountsByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64]entity.IssueSeverityCounts, error)
 }

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"time"
 
 	"github.com/cloudoperators/heureka/internal/entity"
 )
@@ -78,6 +79,13 @@ type Database interface {
 	GetServiceCcrns(context.Context, *entity.ServiceFilter) ([]string, error)
 	GetServiceDomains(context.Context, *entity.ServiceFilter) ([]string, error)
 	GetServiceRegions(context.Context, *entity.ServiceFilter) ([]string, error)
+	GetOwnersByServiceIDs(context.Context, []int64) (map[int64][]entity.User, error)
+	GetSupportGroupsByServiceIDs(context.Context, []int64) (map[int64][]entity.SupportGroup, error)
+	GetIssueCountsByServiceIDs(context.Context, []int64) (map[int64]entity.IssueSeverityCounts, error)
+	GetVersionsByComponentIDs(context.Context, []int64, []*string) (map[int64][]entity.ComponentVersionResult, error)
+	GetIssueCountsByComponentIDs(context.Context, []int64, []*string) (map[int64]entity.IssueSeverityCounts, error)
+	GetVulnerabilitiesByComponentIDs(context.Context, []int64) (map[int64][]entity.VulnerabilityResult, error)
+	GetVulnerabilityCountsByComponentIDs(context.Context, []int64) (map[int64]int, error)
 
 	GetUsers(context.Context, *entity.UserFilter) ([]entity.UserResult, error)
 	GetAllUserIds(context.Context, *entity.UserFilter) ([]int64, error)
@@ -168,4 +176,12 @@ type Database interface {
 	Autopatch(context.Context) (bool, error)
 
 	WaitPostMigrations() error
+
+	// Batch pre-load methods for GetVulnerabilities query optimization
+	GetMaxSeverityByIssueIDs(context.Context, []int64) (map[int64]string, error)
+	GetEarliestRemediationByIssueIDs(context.Context, []int64) (map[int64]time.Time, error)
+	GetSourceURLsByIssueIDs(context.Context, []int64) (map[int64]string, error)
+	GetServicesByIssueIDs(context.Context, []int64) (map[int64][]entity.ServiceResult, error)
+	GetSupportGroupsByIssueIDs(context.Context, []int64) (map[int64][]entity.SupportGroupResult, error)
+	GetVulnerabilityAggregatesByIssueIDs(context.Context, []int64) (map[int64]entity.VulnerabilityAggregate, error)
 }

--- a/internal/database/mariadb/database.go
+++ b/internal/database/mariadb/database.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/cloudoperators/heureka/internal/util"
 	_ "github.com/go-sql-driver/mysql"
@@ -215,6 +216,8 @@ func performListScan[T DatabaseRow, E entity.HeurekaEntity | DatabaseRow](
 	l *logrus.Entry,
 	listBuilder func([]E, T) []E,
 ) ([]E, error) {
+	querycounter.Increment(ctx)
+
 	rows, err := stmt.QueryxContext(ctx, filterParameters...)
 	if err != nil {
 		msg := "Error while performing Query from prepared Statement"
@@ -278,6 +281,8 @@ func performListScan[T DatabaseRow, E entity.HeurekaEntity | DatabaseRow](
 }
 
 func performIdScan(ctx context.Context, stmt Stmt, filterParameters []any, l *logrus.Entry) ([]int64, error) {
+	querycounter.Increment(ctx)
+
 	rows, err := stmt.QueryxContext(ctx, filterParameters...)
 	if err != nil {
 		msg := "Error while performing query with prepared Statement"
@@ -330,6 +335,8 @@ func performIdScan(ctx context.Context, stmt Stmt, filterParameters []any, l *lo
 }
 
 func performCountScan(ctx context.Context, stmt Stmt, filterParameters []any, l *logrus.Entry) (int64, error) {
+	querycounter.Increment(ctx)
+
 	rows, err := stmt.QueryxContext(ctx, filterParameters...)
 	if err != nil {
 		msg := "Error while performing query with prepared Statement"

--- a/internal/database/mariadb/image_batch.go
+++ b/internal/database/mariadb/image_batch.go
@@ -1,0 +1,469 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mariadb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+	"github.com/cloudoperators/heureka/internal/entity"
+	"github.com/sirupsen/logrus"
+)
+
+// GetVersionsByComponentIDs returns component versions grouped by component ID in a single query.
+// This eliminates N+1 queries when loading versions for multiple images.
+// The optional serviceCCRN filter restricts results to versions that have component instances
+// associated with the specified services.
+func (s *SqlDatabase) GetVersionsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64][]entity.ComponentVersionResult, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":        "database.GetVersionsByComponentIDs",
+		"componentIDs": componentIDs,
+	})
+
+	if len(componentIDs) == 0 {
+		return map[int64][]entity.ComponentVersionResult{}, nil
+	}
+
+	query := sq.Select(
+		"CV.componentversion_id",
+		"CV.componentversion_component_id",
+		"CV.componentversion_version",
+		"CV.componentversion_tag",
+		"CV.componentversion_repository",
+		"CV.componentversion_organization",
+		"CV.componentversion_created_at",
+		"CV.componentversion_created_by",
+		"CV.componentversion_deleted_at",
+		"CV.componentversion_updated_at",
+		"CV.componentversion_updated_by",
+		"CV.componentversion_end_of_life",
+	).
+		From("ComponentVersion CV").
+		Where(sq.Eq{"CV.componentversion_component_id": componentIDs}).
+		Where("CV.componentversion_deleted_at IS NULL")
+
+	if len(serviceCCRN) > 0 {
+		nonNilCCRNs := make([]string, 0, len(serviceCCRN))
+		for _, c := range serviceCCRN {
+			if c != nil {
+				nonNilCCRNs = append(nonNilCCRNs, *c)
+			}
+		}
+
+		if len(nonNilCCRNs) > 0 {
+			query = query.
+				Join("ComponentInstance CI ON CV.componentversion_id = CI.componentinstance_component_version_id").
+				Join("Service S ON CI.componentinstance_service_id = S.service_id").
+				Where(sq.Eq{"S.service_ccrn": nonNilCCRNs}).
+				Where("CI.componentinstance_deleted_at IS NULL").
+				Where("S.service_deleted_at IS NULL")
+		}
+	}
+
+	query = query.
+		GroupBy("CV.componentversion_id").
+		OrderBy("CV.componentversion_component_id", "CV.componentversion_version DESC")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetVersionsByComponentIDs query")
+		return nil, fmt.Errorf("GetVersionsByComponentIDs: failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetVersionsByComponentIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetVersionsByComponentIDs query")
+		return nil, fmt.Errorf("GetVersionsByComponentIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.ComponentVersionResult)
+
+	for rows.Next() {
+		var row componentVersionWithComponentRow
+		if err := rows.Scan(
+			&row.ID,
+			&row.ComponentID,
+			&row.Version,
+			&row.Tag,
+			&row.Repository,
+			&row.Organization,
+			&row.CreatedAt,
+			&row.CreatedBy,
+			&row.DeletedAt,
+			&row.UpdatedAt,
+			&row.UpdatedBy,
+			&row.EndOfLife,
+		); err != nil {
+			l.WithError(err).Error("Error scanning GetVersionsByComponentIDs row")
+			return nil, fmt.Errorf("GetVersionsByComponentIDs: error scanning row: %w", err)
+		}
+
+		componentID := GetInt64Value(row.ComponentID)
+		cv := row.asComponentVersion()
+		cvr := entity.ComponentVersionResult{
+			ComponentVersion: &cv,
+		}
+		result[componentID] = append(result[componentID], cvr)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetVersionsByComponentIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetIssueCountsByComponentIDs returns issue severity counts grouped by component ID in a single query.
+// This eliminates N+1 queries when loading vulnerability counts for multiple images.
+// The optional serviceCCRN filter restricts counts to the specified services.
+func (s *SqlDatabase) GetIssueCountsByComponentIDs(ctx context.Context, componentIDs []int64, serviceCCRN []*string) (map[int64]entity.IssueSeverityCounts, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":        "database.GetIssueCountsByComponentIDs",
+		"componentIDs": componentIDs,
+	})
+
+	if len(componentIDs) == 0 {
+		return map[int64]entity.IssueSeverityCounts{}, nil
+	}
+
+	query := sq.Select(
+		"CVR.component_id",
+		"SUM(CVR.critical_count) as critical_count",
+		"SUM(CVR.high_count) as high_count",
+		"SUM(CVR.medium_count) as medium_count",
+		"SUM(CVR.low_count) as low_count",
+		"SUM(CVR.none_count) as none_count",
+	).
+		From("mvSingleComponentByServiceVulnerabilityCounts CVR").
+		Where(sq.Eq{"CVR.component_id": componentIDs})
+
+	if len(serviceCCRN) > 0 {
+		nonNilCCRNs := make([]string, 0, len(serviceCCRN))
+		for _, c := range serviceCCRN {
+			if c != nil {
+				nonNilCCRNs = append(nonNilCCRNs, *c)
+			}
+		}
+
+		if len(nonNilCCRNs) > 0 {
+			query = query.
+				Join("Service S ON CVR.service_id = S.service_id").
+				Where(sq.Eq{"S.service_ccrn": nonNilCCRNs})
+		}
+	}
+
+	query = query.GroupBy("CVR.component_id")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetIssueCountsByComponentIDs query")
+		return nil, fmt.Errorf("GetIssueCountsByComponentIDs: failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetIssueCountsByComponentIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetIssueCountsByComponentIDs query")
+		return nil, fmt.Errorf("GetIssueCountsByComponentIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]entity.IssueSeverityCounts)
+
+	for rows.Next() {
+		var row issueCountWithComponentRow
+		if err := rows.Scan(
+			&row.ComponentID,
+			&row.Critical,
+			&row.High,
+			&row.Medium,
+			&row.Low,
+			&row.None,
+		); err != nil {
+			l.WithError(err).Error("Error scanning GetIssueCountsByComponentIDs row")
+			return nil, fmt.Errorf("GetIssueCountsByComponentIDs: error scanning row: %w", err)
+		}
+
+		isc := row.asIssueSeverityCounts()
+		result[row.ComponentID] = isc
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetIssueCountsByComponentIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}
+
+// componentVersionWithComponentRow is a scan target for the batch versions query.
+type componentVersionWithComponentRow struct {
+	ID           sql.NullInt64  `db:"componentversion_id"`
+	ComponentID  sql.NullInt64  `db:"componentversion_component_id"`
+	Version      sql.NullString `db:"componentversion_version"`
+	Tag          sql.NullString `db:"componentversion_tag"`
+	Repository   sql.NullString `db:"componentversion_repository"`
+	Organization sql.NullString `db:"componentversion_organization"`
+	CreatedAt    sql.NullTime   `db:"componentversion_created_at"`
+	CreatedBy    sql.NullInt64  `db:"componentversion_created_by"`
+	DeletedAt    sql.NullTime   `db:"componentversion_deleted_at"`
+	UpdatedAt    sql.NullTime   `db:"componentversion_updated_at"`
+	UpdatedBy    sql.NullInt64  `db:"componentversion_updated_by"`
+	EndOfLife    sql.NullBool   `db:"componentversion_end_of_life"`
+}
+
+func (r *componentVersionWithComponentRow) asComponentVersion() entity.ComponentVersion {
+	var eol *bool
+	if r.EndOfLife.Valid {
+		eol = &r.EndOfLife.Bool
+	}
+
+	return entity.ComponentVersion{
+		Metadata: entity.Metadata{
+			CreatedAt: GetTimeValue(r.CreatedAt),
+			CreatedBy: GetInt64Value(r.CreatedBy),
+			DeletedAt: GetTimeValue(r.DeletedAt),
+			UpdatedAt: GetTimeValue(r.UpdatedAt),
+			UpdatedBy: GetInt64Value(r.UpdatedBy),
+		},
+		Id:           GetInt64Value(r.ID),
+		ComponentId:  GetInt64Value(r.ComponentID),
+		Version:      GetStringValue(r.Version),
+		Tag:          GetStringValue(r.Tag),
+		Repository:   GetStringValue(r.Repository),
+		Organization: GetStringValue(r.Organization),
+		EndOfLife:    eol,
+	}
+}
+
+// issueCountWithComponentRow is a scan target for the batch issue counts query.
+type issueCountWithComponentRow struct {
+	ComponentID int64         `db:"component_id"`
+	Critical    sql.NullInt64 `db:"critical_count"`
+	High        sql.NullInt64 `db:"high_count"`
+	Medium      sql.NullInt64 `db:"medium_count"`
+	Low         sql.NullInt64 `db:"low_count"`
+	None        sql.NullInt64 `db:"none_count"`
+}
+
+func (r *issueCountWithComponentRow) asIssueSeverityCounts() entity.IssueSeverityCounts {
+	isc := entity.IssueSeverityCounts{
+		Critical: GetInt64Value(r.Critical),
+		High:     GetInt64Value(r.High),
+		Medium:   GetInt64Value(r.Medium),
+		Low:      GetInt64Value(r.Low),
+		None:     GetInt64Value(r.None),
+	}
+	isc.Total = isc.Critical + isc.High + isc.Medium + isc.Low + isc.None
+
+	return isc
+}
+
+// GetVulnerabilitiesByComponentIDs returns active vulnerabilities grouped by component ID
+// using the mvVulnerabilityList materialized view. This eliminates N+1 queries when loading
+// nested vulnerabilities for multiple images.
+// Join path: ComponentVersionIssue → ComponentVersion → Issue → mvVulnerabilityList
+func (s *SqlDatabase) GetVulnerabilitiesByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64][]entity.VulnerabilityResult, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":        "database.GetVulnerabilitiesByComponentIDs",
+		"componentIDs": componentIDs,
+	})
+
+	if len(componentIDs) == 0 {
+		return map[int64][]entity.VulnerabilityResult{}, nil
+	}
+
+	query := sq.Select(
+		"CV.componentversion_component_id",
+		"I.issue_id",
+		"I.issue_primary_name",
+		"I.issue_description",
+		"MVL.max_severity",
+		"MVL.earliest_remediation_date",
+		"MVL.source_url",
+	).
+		From("ComponentVersionIssue CVI").
+		Join("ComponentVersion CV ON CVI.componentversionissue_component_version_id = CV.componentversion_id").
+		Join("Issue I ON CVI.componentversionissue_issue_id = I.issue_id").
+		Join("mvVulnerabilityList MVL ON I.issue_id = MVL.issue_id").
+		Where(sq.Eq{"CV.componentversion_component_id": componentIDs}).
+		Where("CVI.componentversionissue_deleted_at IS NULL").
+		Where("CV.componentversion_deleted_at IS NULL").
+		Where("I.issue_deleted_at IS NULL").
+		GroupBy("CV.componentversion_component_id", "I.issue_id").
+		OrderBy(
+			"CV.componentversion_component_id",
+			"FIELD(MVL.max_severity, 'Critical','High','Medium','Low','None') ASC",
+			"I.issue_primary_name ASC",
+		)
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetVulnerabilitiesByComponentIDs query")
+		return nil, fmt.Errorf("GetVulnerabilitiesByComponentIDs: failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetVulnerabilitiesByComponentIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetVulnerabilitiesByComponentIDs query")
+		return nil, fmt.Errorf("GetVulnerabilitiesByComponentIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.VulnerabilityResult)
+
+	for rows.Next() {
+		var componentID sql.NullInt64
+
+		var issueID sql.NullInt64
+
+		var primaryName sql.NullString
+
+		var description sql.NullString
+
+		var severity sql.NullString
+
+		var remediationDate sql.NullTime
+
+		var sourceURL sql.NullString
+
+		if err := rows.Scan(
+			&componentID,
+			&issueID,
+			&primaryName,
+			&description,
+			&severity,
+			&remediationDate,
+			&sourceURL,
+		); err != nil {
+			l.WithError(err).Error("Error scanning GetVulnerabilitiesByComponentIDs row")
+			return nil, fmt.Errorf("GetVulnerabilitiesByComponentIDs: error scanning row: %w", err)
+		}
+
+		if !componentID.Valid || !issueID.Valid {
+			continue
+		}
+
+		vr := entity.VulnerabilityResult{
+			IssueID:     issueID.Int64,
+			PrimaryName: GetStringValue(primaryName),
+			Description: GetStringValue(description),
+			MaxSeverity: GetStringValue(severity),
+		}
+		if remediationDate.Valid {
+			vr.EarliestRemediationDate = &remediationDate.Time
+		}
+
+		if sourceURL.Valid {
+			vr.SourceURL = sourceURL.String
+		}
+
+		result[componentID.Int64] = append(result[componentID.Int64], vr)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetVulnerabilitiesByComponentIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetVulnerabilityCountsByComponentIDs returns the total count of active vulnerabilities
+// per component ID using the mvVulnerabilityList materialized view.
+func (s *SqlDatabase) GetVulnerabilityCountsByComponentIDs(ctx context.Context, componentIDs []int64) (map[int64]int, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":        "database.GetVulnerabilityCountsByComponentIDs",
+		"componentIDs": componentIDs,
+	})
+
+	if len(componentIDs) == 0 {
+		return map[int64]int{}, nil
+	}
+
+	query := sq.Select(
+		"CV.componentversion_component_id",
+		"COUNT(DISTINCT CVI.componentversionissue_issue_id) as vuln_count",
+	).
+		From("ComponentVersionIssue CVI").
+		Join("ComponentVersion CV ON CVI.componentversionissue_component_version_id = CV.componentversion_id").
+		Join("mvVulnerabilityList MVL ON CVI.componentversionissue_issue_id = MVL.issue_id").
+		Where(sq.Eq{"CV.componentversion_component_id": componentIDs}).
+		Where("CVI.componentversionissue_deleted_at IS NULL").
+		Where("CV.componentversion_deleted_at IS NULL").
+		GroupBy("CV.componentversion_component_id")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetVulnerabilityCountsByComponentIDs query")
+		return nil, fmt.Errorf("GetVulnerabilityCountsByComponentIDs: failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetVulnerabilityCountsByComponentIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetVulnerabilityCountsByComponentIDs query")
+		return nil, fmt.Errorf("GetVulnerabilityCountsByComponentIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]int)
+
+	for rows.Next() {
+		var componentID sql.NullInt64
+
+		var count sql.NullInt64
+
+		if err := rows.Scan(&componentID, &count); err != nil {
+			l.WithError(err).Error("Error scanning GetVulnerabilityCountsByComponentIDs row")
+			return nil, fmt.Errorf("GetVulnerabilityCountsByComponentIDs: error scanning row: %w", err)
+		}
+
+		if componentID.Valid {
+			result[componentID.Int64] = int(GetInt64Value(count))
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetVulnerabilityCountsByComponentIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -221,6 +221,15 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 				return (f.Status == entity.IssueStatusOpen || f.Status == entity.IssueStatusRemediated) && !hasService && !hasComponent
 			},
 		},
+		{
+			Name:  "MVL",
+			Type:  InnerJoin,
+			Table: "(SELECT issue_id AS mvl_issue_id, max_severity, earliest_remediation_date, source_url FROM mvVulnerabilityList) MVL",
+			On:    "I.issue_id = MVL.mvl_issue_id",
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return f.UseMvVulnerabilityList
+			},
+		},
 	},
 	ExtraColumnsSelector: func(_ *entity.IssueFilter, order *Order) []string {
 		for _, o := range order.Sequence() {

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -37,6 +37,7 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 		NewFilterProperty("I.issue_id = ?", func(filter *entity.IssueFilter) any { return filter.Id }),
 		NewFilterProperty("IM.issuematch_status = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchStatus }),
 		NewFilterProperty("IM.issuematch_rating = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchSeverity }),
+		NewFilterProperty("MVL.max_severity = ?", func(filter *entity.IssueFilter) any { return filter.MvSeverity }),
 		NewFilterProperty("IM.issuematch_id = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchId }),
 		NewFilterProperty("CVI.componentversionissue_component_version_id = ?", func(filter *entity.IssueFilter) any { return filter.ComponentVersionId }),
 		NewFilterProperty("IV.issuevariant_id = ?", func(filter *entity.IssueFilter) any { return filter.IssueVariantId }),
@@ -98,7 +99,9 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			Table:     "ComponentInstance CI",
 			On:        "IM.issuematch_component_instance_id = CI.componentinstance_id",
 			DependsOn: []string{"IM_LJ"},
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.ServiceId) > 0 },
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return len(f.ServiceId) > 0 && !f.UseMvVulnerabilityList
+			},
 		},
 		{
 			Name:      "CV with IM_RJ",
@@ -114,7 +117,9 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			Table:     "ComponentVersion CV",
 			On:        "CI.componentinstance_component_version_id = CV.componentversion_id",
 			DependsOn: []string{"CI with IM_LJ"},
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.ServiceCCRN) > 0 },
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList
+			},
 		},
 		{
 			Name:      "S with IM_RJ",
@@ -130,7 +135,9 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			Table:     "Service S",
 			On:        "CI.componentinstance_service_id = S.service_id",
 			DependsOn: []string{"CI with IM_LJ"},
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.ServiceCCRN) > 0 },
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList
+			},
 		},
 		{
 			Name:      "SGS",
@@ -146,7 +153,9 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			Table:     "SupportGroup SG",
 			On:        "SGS.supportgroupservice_support_group_id = SG.supportgroup_id",
 			DependsOn: []string{"SGS"},
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.SupportGroupCCRN) > 0 },
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return len(f.SupportGroupCCRN) > 0 && !f.UseMvVulnerabilityList
+			},
 		},
 		{
 			Name:  "IV",
@@ -228,6 +237,46 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			On:    "I.issue_id = MVL.mvl_issue_id",
 			Condition: func(f *entity.IssueFilter, _ *Order) bool {
 				return f.UseMvVulnerabilityList
+			},
+		},
+		{
+			Name:      "MVS",
+			Type:      InnerJoin,
+			Table:     "(SELECT issue_id AS mvs_issue_id, service_id AS mvs_service_id FROM mvVulnerabilityService) MVS",
+			On:        "I.issue_id = MVS.mvs_issue_id",
+			DependsOn: []string{"MVL"},
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return f.UseMvVulnerabilityList && (len(f.ServiceCCRN) > 0 || len(f.ServiceId) > 0 || len(f.SupportGroupCCRN) > 0)
+			},
+		},
+		{
+			Name:      "S with MVS",
+			Type:      InnerJoin,
+			Table:     "Service S",
+			On:        "MVS.mvs_service_id = S.service_id",
+			DependsOn: []string{"MVS"},
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return f.UseMvVulnerabilityList && len(f.ServiceCCRN) > 0
+			},
+		},
+		{
+			Name:      "SGS with MVS",
+			Type:      InnerJoin,
+			Table:     "SupportGroupService SGS",
+			On:        "MVS.mvs_service_id = SGS.supportgroupservice_service_id",
+			DependsOn: []string{"MVS"},
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return f.UseMvVulnerabilityList && len(f.SupportGroupCCRN) > 0
+			},
+		},
+		{
+			Name:      "SG with MVS",
+			Type:      InnerJoin,
+			Table:     "SupportGroup SG",
+			On:        "SGS.supportgroupservice_support_group_id = SG.supportgroup_id",
+			DependsOn: []string{"SGS with MVS"},
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return f.UseMvVulnerabilityList && len(f.SupportGroupCCRN) > 0
 			},
 		},
 	},

--- a/internal/database/mariadb/migration.go
+++ b/internal/database/mariadb/migration.go
@@ -159,6 +159,7 @@ func registerEvents(cfg util.Config) error {
 		"refresh_mvCountIssueRatingsServiceId",
 		"refresh_mvCountIssueRatingsOther",
 		"refresh_mvVulnerabilityList",
+		"refresh_mvVulnerabilityService",
 	}
 
 	db, err := GetSqlxConnection(cfg)

--- a/internal/database/mariadb/migration.go
+++ b/internal/database/mariadb/migration.go
@@ -158,6 +158,7 @@ func registerEvents(cfg util.Config) error {
 		"refresh_mvCountIssueRatingsComponentVersion",
 		"refresh_mvCountIssueRatingsServiceId",
 		"refresh_mvCountIssueRatingsOther",
+		"refresh_mvVulnerabilityList",
 	}
 
 	db, err := GetSqlxConnection(cfg)

--- a/internal/database/mariadb/migrations/20260610120000_add_mv_vulnerability_list.down.sql
+++ b/internal/database/mariadb/migrations/20260610120000_add_mv_vulnerability_list.down.sql
@@ -1,0 +1,5 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+DROP PROCEDURE IF EXISTS refresh_mvVulnerabilityList_proc;
+DROP TABLE IF EXISTS mvVulnerabilityList;

--- a/internal/database/mariadb/migrations/20260610120000_add_mv_vulnerability_list.up.sql
+++ b/internal/database/mariadb/migrations/20260610120000_add_mv_vulnerability_list.up.sql
@@ -1,0 +1,53 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Materialized view for vulnerability list: pre-computes which issues are active
+-- vulnerabilities (type=Vulnerability, has at least one IssueMatch with status=new)
+-- along with pre-aggregated severity, remediation date, and source URL.
+-- This eliminates the expensive RIGHT JOIN on IssueMatch (10M+ rows) for the
+-- GetVulnerabilities UI query.
+
+CREATE TABLE IF NOT EXISTS mvVulnerabilityList (
+    issue_id INT UNSIGNED NOT NULL PRIMARY KEY,
+    max_severity ENUM('None','Low','Medium','High','Critical') NOT NULL DEFAULT 'None',
+    earliest_remediation_date TIMESTAMP NULL,
+    source_url VARCHAR(2048) NULL,
+    INDEX idx_severity (max_severity)
+);
+
+DROP PROCEDURE IF EXISTS refresh_mvVulnerabilityList_proc;
+CREATE PROCEDURE refresh_mvVulnerabilityList_proc()
+BEGIN
+    -- Ensure clean state for atomic swap
+    DROP TABLE IF EXISTS mvVulnerabilityList_tmp;
+    DROP TABLE IF EXISTS mvVulnerabilityList_old;
+
+    CREATE TABLE mvVulnerabilityList_tmp LIKE mvVulnerabilityList;
+
+    INSERT INTO mvVulnerabilityList_tmp (issue_id, max_severity, earliest_remediation_date, source_url)
+    SELECT
+        I.issue_id,
+        MAX(IM.issuematch_rating) as max_severity,
+        MIN(IM.issuematch_target_remediation_date) as earliest_remediation_date,
+        (SELECT MIN(IV.issuevariant_external_url)
+         FROM IssueVariant IV
+         WHERE IV.issuevariant_issue_id = I.issue_id
+           AND IV.issuevariant_deleted_at IS NULL
+           AND IV.issuevariant_external_url != '') as source_url
+    FROM Issue I
+    RIGHT JOIN IssueMatch IM ON I.issue_id = IM.issuematch_issue_id
+    WHERE IM.issuematch_status = 'new'
+      AND IM.issuematch_deleted_at IS NULL
+      AND I.issue_type = 'Vulnerability'
+      AND I.issue_deleted_at IS NULL
+    GROUP BY I.issue_id;
+
+    RENAME TABLE
+        mvVulnerabilityList TO mvVulnerabilityList_old,
+        mvVulnerabilityList_tmp TO mvVulnerabilityList;
+
+    DROP TABLE IF EXISTS mvVulnerabilityList_old;
+END;
+
+-- Initial population
+CALL refresh_mvVulnerabilityList_proc();

--- a/internal/database/mariadb/migrations/20260610140000_add_mv_vulnerability_service.down.sql
+++ b/internal/database/mariadb/migrations/20260610140000_add_mv_vulnerability_service.down.sql
@@ -1,0 +1,7 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+DROP PROCEDURE IF EXISTS refresh_mvVulnerabilityService_proc;
+DROP TABLE IF EXISTS mvVulnerabilityService;
+DROP TABLE IF EXISTS mvVulnerabilityService_tmp;
+DROP TABLE IF EXISTS mvVulnerabilityService_old;

--- a/internal/database/mariadb/migrations/20260610140000_add_mv_vulnerability_service.up.sql
+++ b/internal/database/mariadb/migrations/20260610140000_add_mv_vulnerability_service.up.sql
@@ -1,0 +1,40 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Junction materialized view mapping vulnerabilities to services.
+-- Eliminates the need to join through IssueMatch (10M rows) when filtering
+-- vulnerabilities by service or support group.
+-- Depends on mvVulnerabilityList being populated first.
+
+CREATE TABLE IF NOT EXISTS mvVulnerabilityService (
+    issue_id INT UNSIGNED NOT NULL,
+    service_id INT UNSIGNED NOT NULL,
+    PRIMARY KEY (service_id, issue_id),
+    INDEX idx_issue (issue_id)
+);
+
+DROP PROCEDURE IF EXISTS refresh_mvVulnerabilityService_proc;
+CREATE PROCEDURE refresh_mvVulnerabilityService_proc()
+BEGIN
+    DROP TABLE IF EXISTS mvVulnerabilityService_tmp;
+    DROP TABLE IF EXISTS mvVulnerabilityService_old;
+
+    CREATE TABLE mvVulnerabilityService_tmp LIKE mvVulnerabilityService;
+
+    INSERT INTO mvVulnerabilityService_tmp (issue_id, service_id)
+    SELECT DISTINCT MVL.issue_id, CI.componentinstance_service_id
+    FROM mvVulnerabilityList MVL
+    JOIN IssueMatch IM ON MVL.issue_id = IM.issuematch_issue_id
+    JOIN ComponentInstance CI ON IM.issuematch_component_instance_id = CI.componentinstance_id
+    WHERE IM.issuematch_deleted_at IS NULL
+      AND CI.componentinstance_deleted_at IS NULL;
+
+    RENAME TABLE
+        mvVulnerabilityService TO mvVulnerabilityService_old,
+        mvVulnerabilityService_tmp TO mvVulnerabilityService;
+
+    DROP TABLE IF EXISTS mvVulnerabilityService_old;
+END;
+
+-- Initial population
+CALL refresh_mvVulnerabilityService_proc();

--- a/internal/database/mariadb/service_batch.go
+++ b/internal/database/mariadb/service_batch.go
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mariadb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+	"github.com/cloudoperators/heureka/internal/entity"
+	"github.com/sirupsen/logrus"
+)
+
+// ownerWithServiceRow is a scan target for the batch owners query.
+type ownerWithServiceRow struct {
+	UserID       sql.NullInt64  `db:"user_id"`
+	UserName     sql.NullString `db:"user_name"`
+	UniqueUserID sql.NullString `db:"user_unique_user_id"`
+	UserType     sql.NullInt64  `db:"user_type"`
+	UserEmail    sql.NullString `db:"user_email"`
+	CreatedAt    sql.NullTime   `db:"user_created_at"`
+	CreatedBy    sql.NullInt64  `db:"user_created_by"`
+	DeletedAt    sql.NullTime   `db:"user_deleted_at"`
+	UpdatedAt    sql.NullTime   `db:"user_updated_at"`
+	UpdatedBy    sql.NullInt64  `db:"user_updated_by"`
+	ServiceID    sql.NullInt64  `db:"owner_service_id"`
+}
+
+func (r *ownerWithServiceRow) asUser() entity.User {
+	return entity.User{
+		Id:           GetInt64Value(r.UserID),
+		Name:         GetStringValue(r.UserName),
+		UniqueUserID: GetStringValue(r.UniqueUserID),
+		Type:         GetUserTypeValue(r.UserType),
+		Email:        GetStringValue(r.UserEmail),
+		Metadata: entity.Metadata{
+			CreatedAt: GetTimeValue(r.CreatedAt),
+			CreatedBy: GetInt64Value(r.CreatedBy),
+			DeletedAt: GetTimeValue(r.DeletedAt),
+			UpdatedAt: GetTimeValue(r.UpdatedAt),
+			UpdatedBy: GetInt64Value(r.UpdatedBy),
+		},
+	}
+}
+
+// supportGroupWithServiceRow is a scan target for the batch support groups query.
+type supportGroupWithServiceRow struct {
+	SGID      sql.NullInt64  `db:"supportgroup_id"`
+	SGCCRN    sql.NullString `db:"supportgroup_ccrn"`
+	CreatedAt sql.NullTime   `db:"supportgroup_created_at"`
+	CreatedBy sql.NullInt64  `db:"supportgroup_created_by"`
+	DeletedAt sql.NullTime   `db:"supportgroup_deleted_at"`
+	UpdatedAt sql.NullTime   `db:"supportgroup_updated_at"`
+	UpdatedBy sql.NullInt64  `db:"supportgroup_updated_by"`
+	ServiceID sql.NullInt64  `db:"supportgroupservice_service_id"`
+}
+
+func (r *supportGroupWithServiceRow) asSupportGroup() entity.SupportGroup {
+	return entity.SupportGroup{
+		Id:   GetInt64Value(r.SGID),
+		CCRN: GetStringValue(r.SGCCRN),
+		Metadata: entity.Metadata{
+			CreatedAt: GetTimeValue(r.CreatedAt),
+			CreatedBy: GetInt64Value(r.CreatedBy),
+			DeletedAt: GetTimeValue(r.DeletedAt),
+			UpdatedAt: GetTimeValue(r.UpdatedAt),
+			UpdatedBy: GetInt64Value(r.UpdatedBy),
+		},
+	}
+}
+
+// issueCountWithServiceRow is a scan target for the batch issue counts query.
+type issueCountWithServiceRow struct {
+	ServiceID int64         `db:"service_id"`
+	Critical  sql.NullInt64 `db:"critical_count"`
+	High      sql.NullInt64 `db:"high_count"`
+	Medium    sql.NullInt64 `db:"medium_count"`
+	Low       sql.NullInt64 `db:"low_count"`
+	None      sql.NullInt64 `db:"none_count"`
+}
+
+func (r *issueCountWithServiceRow) asIssueSeverityCounts() entity.IssueSeverityCounts {
+	isc := entity.IssueSeverityCounts{
+		Critical: GetInt64Value(r.Critical),
+		High:     GetInt64Value(r.High),
+		Medium:   GetInt64Value(r.Medium),
+		Low:      GetInt64Value(r.Low),
+		None:     GetInt64Value(r.None),
+	}
+	isc.Total = isc.Critical + isc.High + isc.Medium + isc.Low + isc.None
+
+	return isc
+}
+
+// GetOwnersByServiceIDs returns owners (users) grouped by service ID in a single query.
+// This eliminates N+1 queries when loading owners for multiple services.
+func (s *SqlDatabase) GetOwnersByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64][]entity.User, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "database.GetOwnersByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	if len(serviceIDs) == 0 {
+		return map[int64][]entity.User{}, nil
+	}
+
+	placeholders := make([]string, len(serviceIDs))
+	args := make([]any, len(serviceIDs))
+
+	for i, id := range serviceIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT U.user_id, U.user_name, U.user_unique_user_id, U.user_type, U.user_email,
+		       U.user_created_at, U.user_created_by, U.user_deleted_at, U.user_updated_at, U.user_updated_by,
+		       O.owner_service_id
+		FROM Owner O
+		JOIN User U ON O.owner_user_id = U.user_id
+		WHERE O.owner_service_id IN (%s)
+		  AND O.owner_deleted_at IS NULL
+		  AND U.user_deleted_at IS NULL
+		ORDER BY O.owner_service_id, U.user_id
+	`, strings.Join(placeholders, ","))
+
+	stmt, err := s.db.PreparexContext(ctx, query)
+	if err != nil {
+		l.WithField("error", err).Error("Error preparing statement")
+		return nil, fmt.Errorf("GetOwnersByServiceIDs: error preparing statement: %w", err)
+	}
+
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			l.Warnf("error closing statement: %s", err)
+		}
+	}()
+
+	querycounter.Increment(ctx)
+
+	rows, err := stmt.QueryxContext(ctx, args...)
+	if err != nil {
+		l.WithField("error", err).Error("Error executing query")
+		return nil, fmt.Errorf("GetOwnersByServiceIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.User)
+
+	for rows.Next() {
+		var row ownerWithServiceRow
+		if err := rows.StructScan(&row); err != nil {
+			l.WithField("error", err).Error("Error scanning row")
+			return nil, fmt.Errorf("GetOwnersByServiceIDs: error scanning row: %w", err)
+		}
+
+		serviceID := GetInt64Value(row.ServiceID)
+		user := row.asUser()
+		result[serviceID] = append(result[serviceID], user)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetOwnersByServiceIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetSupportGroupsByServiceIDs returns support groups grouped by service ID in a single query.
+// This eliminates N+1 queries when loading support groups for multiple services.
+func (s *SqlDatabase) GetSupportGroupsByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64][]entity.SupportGroup, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "database.GetSupportGroupsByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	if len(serviceIDs) == 0 {
+		return map[int64][]entity.SupportGroup{}, nil
+	}
+
+	placeholders := make([]string, len(serviceIDs))
+	args := make([]any, len(serviceIDs))
+
+	for i, id := range serviceIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT SG.supportgroup_id, SG.supportgroup_ccrn,
+		       SG.supportgroup_created_at, SG.supportgroup_created_by,
+		       SG.supportgroup_deleted_at, SG.supportgroup_updated_at, SG.supportgroup_updated_by,
+		       SGS.supportgroupservice_service_id
+		FROM SupportGroupService SGS
+		JOIN SupportGroup SG ON SGS.supportgroupservice_support_group_id = SG.supportgroup_id
+		WHERE SGS.supportgroupservice_service_id IN (%s)
+		  AND SGS.supportgroupservice_deleted_at IS NULL
+		  AND SG.supportgroup_deleted_at IS NULL
+		ORDER BY SGS.supportgroupservice_service_id, SG.supportgroup_id
+	`, strings.Join(placeholders, ","))
+
+	stmt, err := s.db.PreparexContext(ctx, query)
+	if err != nil {
+		l.WithField("error", err).Error("Error preparing statement")
+		return nil, fmt.Errorf("GetSupportGroupsByServiceIDs: error preparing statement: %w", err)
+	}
+
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			l.Warnf("error closing statement: %s", err)
+		}
+	}()
+
+	querycounter.Increment(ctx)
+
+	rows, err := stmt.QueryxContext(ctx, args...)
+	if err != nil {
+		l.WithField("error", err).Error("Error executing query")
+		return nil, fmt.Errorf("GetSupportGroupsByServiceIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.SupportGroup)
+
+	for rows.Next() {
+		var row supportGroupWithServiceRow
+		if err := rows.StructScan(&row); err != nil {
+			l.WithField("error", err).Error("Error scanning row")
+			return nil, fmt.Errorf("GetSupportGroupsByServiceIDs: error scanning row: %w", err)
+		}
+
+		serviceID := GetInt64Value(row.ServiceID)
+		sg := row.asSupportGroup()
+		result[serviceID] = append(result[serviceID], sg)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetSupportGroupsByServiceIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetIssueCountsByServiceIDs returns issue severity counts grouped by service ID in a single query.
+// This eliminates N+1 queries when loading issue counts for multiple services.
+func (s *SqlDatabase) GetIssueCountsByServiceIDs(ctx context.Context, serviceIDs []int64) (map[int64]entity.IssueSeverityCounts, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"event":      "database.GetIssueCountsByServiceIDs",
+		"serviceIDs": serviceIDs,
+	})
+
+	if len(serviceIDs) == 0 {
+		return map[int64]entity.IssueSeverityCounts{}, nil
+	}
+
+	placeholders := make([]string, len(serviceIDs))
+	args := make([]any, len(serviceIDs))
+
+	for i, id := range serviceIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT service_id, critical_count, high_count, medium_count, low_count, none_count
+		FROM mvServiceIssueCounts
+		WHERE service_id IN (%s)
+	`, strings.Join(placeholders, ","))
+
+	stmt, err := s.db.PreparexContext(ctx, query)
+	if err != nil {
+		l.WithField("error", err).Error("Error preparing statement")
+		return nil, fmt.Errorf("GetIssueCountsByServiceIDs: error preparing statement: %w", err)
+	}
+
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			l.Warnf("error closing statement: %s", err)
+		}
+	}()
+
+	querycounter.Increment(ctx)
+
+	rows, err := stmt.QueryxContext(ctx, args...)
+	if err != nil {
+		l.WithField("error", err).Error("Error executing query")
+		return nil, fmt.Errorf("GetIssueCountsByServiceIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]entity.IssueSeverityCounts)
+
+	for rows.Next() {
+		var row issueCountWithServiceRow
+		if err := rows.StructScan(&row); err != nil {
+			l.WithField("error", err).Error("Error scanning row")
+			return nil, fmt.Errorf("GetIssueCountsByServiceIDs: error scanning row: %w", err)
+		}
+
+		isc := row.asIssueSeverityCounts()
+		result[row.ServiceID] = isc
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetIssueCountsByServiceIDs: row iteration error: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/database/mariadb/service_batch_test.go
+++ b/internal/database/mariadb/service_batch_test.go
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mariadb_test
+
+import (
+	"context"
+
+	"github.com/cloudoperators/heureka/internal/database/mariadb"
+	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+)
+
+var _ = Describe("Service Batch", Label("database", "ServiceBatch"), func() {
+	var db *mariadb.SqlDatabase
+
+	var seeder *test.DatabaseSeeder
+
+	BeforeEach(func() {
+		var err error
+
+		db = dbm.NewTestSchema()
+		seeder, err = test.NewDatabaseSeeder(dbm.DbConfig())
+		Expect(err).To(BeNil(), "Database Seeder Setup should work")
+	})
+	AfterEach(func() {
+		dbm.TestTearDown(db)
+	})
+
+	When("Getting Owners By Service IDs", Label("GetOwnersByServiceIDs"), func() {
+		Context("and the database is empty", func() {
+			It("returns empty map for empty input", func() {
+				res, err := db.GetOwnersByServiceIDs(context.Background(), []int64{})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			It("returns empty map for non-existent IDs", func() {
+				res, err := db.GetOwnersByServiceIDs(context.Background(), []int64{99999})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("and we have seeded data", func() {
+			var seedCollection *test.SeedCollection
+
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+			})
+
+			It("returns owners grouped by service ID correctly", func() {
+				serviceIDs := lo.Map(seedCollection.ServiceRows, func(s mariadb.BaseServiceRow, _ int) int64 {
+					return s.Id.Int64
+				})
+
+				res, err := db.GetOwnersByServiceIDs(context.Background(), serviceIDs)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning correct owner mappings", func() {
+					for _, ownerRow := range seedCollection.OwnerRows {
+						serviceID := ownerRow.ServiceId.Int64
+						userID := ownerRow.UserId.Int64
+
+						users, exists := res[serviceID]
+						if !exists {
+							continue
+						}
+
+						hasUser := false
+
+						for _, u := range users {
+							if u.Id == userID {
+								hasUser = true
+								break
+							}
+						}
+
+						Expect(hasUser).To(BeTrue(), "Expected user %d to be owner of service %d", userID, serviceID)
+					}
+				})
+			})
+
+			It("returns data for a single service ID", func() {
+				var targetServiceID int64
+				for _, ownerRow := range seedCollection.OwnerRows {
+					targetServiceID = ownerRow.ServiceId.Int64
+					break
+				}
+
+				if targetServiceID == 0 {
+					Skip("No owners found in seed data")
+				}
+
+				res, err := db.GetOwnersByServiceIDs(context.Background(), []int64{targetServiceID})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning owners for the requested service only", func() {
+					Expect(res).To(HaveLen(1))
+					Expect(res).To(HaveKey(targetServiceID))
+					Expect(res[targetServiceID]).ToNot(BeEmpty())
+				})
+			})
+		})
+	})
+
+	When("Getting Support Groups By Service IDs", Label("GetSupportGroupsByServiceIDs"), func() {
+		Context("and the database is empty", func() {
+			It("returns empty map for empty input", func() {
+				res, err := db.GetSupportGroupsByServiceIDs(context.Background(), []int64{})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			It("returns empty map for non-existent IDs", func() {
+				res, err := db.GetSupportGroupsByServiceIDs(context.Background(), []int64{99999})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("and we have seeded data", func() {
+			var seedCollection *test.SeedCollection
+
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+			})
+
+			It("returns support groups grouped by service ID correctly", func() {
+				serviceIDs := lo.Map(seedCollection.ServiceRows, func(s mariadb.BaseServiceRow, _ int) int64 {
+					return s.Id.Int64
+				})
+
+				res, err := db.GetSupportGroupsByServiceIDs(context.Background(), serviceIDs)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning correct support group mappings", func() {
+					for _, sgsRow := range seedCollection.SupportGroupServiceRows {
+						serviceID := sgsRow.ServiceId.Int64
+						sgID := sgsRow.SupportGroupId.Int64
+
+						sgs, exists := res[serviceID]
+						if !exists {
+							continue
+						}
+
+						hasSG := false
+
+						for _, sg := range sgs {
+							if sg.Id == sgID {
+								hasSG = true
+								break
+							}
+						}
+
+						Expect(hasSG).To(BeTrue(), "Expected support group %d to be linked to service %d", sgID, serviceID)
+					}
+				})
+			})
+
+			It("returns data for a single service ID", func() {
+				var targetServiceID int64
+				for _, sgsRow := range seedCollection.SupportGroupServiceRows {
+					targetServiceID = sgsRow.ServiceId.Int64
+					break
+				}
+
+				if targetServiceID == 0 {
+					Skip("No support group services found in seed data")
+				}
+
+				res, err := db.GetSupportGroupsByServiceIDs(context.Background(), []int64{targetServiceID})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning support groups for the requested service only", func() {
+					Expect(res).To(HaveLen(1))
+					Expect(res).To(HaveKey(targetServiceID))
+					Expect(res[targetServiceID]).ToNot(BeEmpty())
+				})
+			})
+		})
+	})
+
+	When("Getting Issue Counts By Service IDs", Label("GetIssueCountsByServiceIDs"), func() {
+		Context("and the database is empty", func() {
+			It("returns empty map for empty input", func() {
+				res, err := db.GetIssueCountsByServiceIDs(context.Background(), []int64{})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+
+			It("returns empty map for non-existent IDs", func() {
+				res, err := db.GetIssueCountsByServiceIDs(context.Background(), []int64{99999})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+				By("returning an empty map", func() {
+					Expect(res).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("and we have seeded data", func() {
+			var seedCollection *test.SeedCollection
+
+			BeforeEach(func() {
+				seedCollection = seeder.SeedDbWithNFakeData(10)
+			})
+
+			It("returns issue counts grouped by service ID", func() {
+				serviceIDs := lo.Map(seedCollection.ServiceRows, func(s mariadb.BaseServiceRow, _ int) int64 {
+					return s.Id.Int64
+				})
+
+				res, err := db.GetIssueCountsByServiceIDs(context.Background(), serviceIDs)
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning valid severity counts", func() {
+					for _, counts := range res {
+						Expect(counts.Critical).To(BeNumerically(">=", 0))
+						Expect(counts.High).To(BeNumerically(">=", 0))
+						Expect(counts.Medium).To(BeNumerically(">=", 0))
+						Expect(counts.Low).To(BeNumerically(">=", 0))
+						Expect(counts.None).To(BeNumerically(">=", 0))
+						Expect(counts.Total).To(Equal(
+							counts.Critical + counts.High + counts.Medium + counts.Low + counts.None,
+						))
+					}
+				})
+			})
+
+			It("returns data for a single service ID", func() {
+				if len(seedCollection.ServiceRows) == 0 {
+					Skip("No services found in seed data")
+				}
+
+				targetServiceID := seedCollection.ServiceRows[0].Id.Int64
+				res, err := db.GetIssueCountsByServiceIDs(context.Background(), []int64{targetServiceID})
+
+				By("throwing no error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning at most one entry", func() {
+					Expect(len(res)).To(BeNumerically("<=", 1))
+				})
+			})
+		})
+	})
+})

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -330,6 +330,17 @@ func (s *SeedCollection) FindLinkedRemediationData() (mariadb.BaseServiceRow, ma
 			continue
 		}
 
+		// Skip triples that already have a seeded remediation to avoid
+		// "already exists" conflicts in create-remediation tests.
+		hasExisting := lo.ContainsBy(s.RemediationRows, func(r mariadb.RemediationRow) bool {
+			return r.ServiceId.Int64 == service.Id.Int64 &&
+				r.IssueId.Int64 == issue.Id.Int64 &&
+				r.ComponentId.Int64 == component.Id.Int64
+		})
+		if hasExisting {
+			continue
+		}
+
 		return service, component, issue, true
 	}
 

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -2113,3 +2113,9 @@ func (s *DatabaseSeeder) RefreshComponentVulnerabilityCounts() error {
 
 	return err
 }
+
+func (s *DatabaseSeeder) RefreshMvVulnerabilityList() error {
+	_, err := s.db.Exec(`CALL refresh_mvVulnerabilityList_proc();`)
+
+	return err
+}

--- a/internal/database/mariadb/vulnerability_batch.go
+++ b/internal/database/mariadb/vulnerability_batch.go
@@ -1,0 +1,498 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mariadb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+	"github.com/cloudoperators/heureka/internal/entity"
+	"github.com/sirupsen/logrus"
+)
+
+// GetMaxSeverityByIssueIDs returns the highest severity rating per issue in a single aggregate query.
+// It queries IssueMatch grouped by issue_id and picks the max rating using the ENUM ordering
+// (Critical > High > Medium > Low > None).
+func (s *SqlDatabase) GetMaxSeverityByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]string, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetMaxSeverityByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64]string{}, nil
+	}
+
+	// MariaDB ENUM ordering: 'None'=1, 'Low'=2, 'Medium'=3, 'High'=4, 'Critical'=5
+	// MAX on ENUM uses the internal index, so MAX gives highest severity.
+	query := sq.Select(
+		"IM.issuematch_issue_id",
+		"MAX(IM.issuematch_rating) as max_severity",
+	).
+		From("IssueMatch IM").
+		Where(sq.Eq{"IM.issuematch_issue_id": issueIDs}).
+		Where("IM.issuematch_deleted_at IS NULL").
+		GroupBy("IM.issuematch_issue_id")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetMaxSeverityByIssueIDs query")
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetMaxSeverityByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetMaxSeverityByIssueIDs query")
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]string)
+
+	for rows.Next() {
+		var issueID sql.NullInt64
+
+		var severity sql.NullString
+		if err := rows.Scan(&issueID, &severity); err != nil {
+			l.WithError(err).Error("Error scanning GetMaxSeverityByIssueIDs row")
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if issueID.Valid && severity.Valid {
+			result[issueID.Int64] = severity.String
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetEarliestRemediationByIssueIDs returns the earliest target remediation date per issue.
+func (s *SqlDatabase) GetEarliestRemediationByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]time.Time, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetEarliestRemediationByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64]time.Time{}, nil
+	}
+
+	query := sq.Select(
+		"IM.issuematch_issue_id",
+		"MIN(IM.issuematch_target_remediation_date) as earliest_date",
+	).
+		From("IssueMatch IM").
+		Where(sq.Eq{"IM.issuematch_issue_id": issueIDs}).
+		Where("IM.issuematch_deleted_at IS NULL").
+		GroupBy("IM.issuematch_issue_id")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetEarliestRemediationByIssueIDs query")
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetEarliestRemediationByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetEarliestRemediationByIssueIDs query")
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]time.Time)
+
+	for rows.Next() {
+		var issueID sql.NullInt64
+
+		var earliestDate sql.NullTime
+
+		if err := rows.Scan(&issueID, &earliestDate); err != nil {
+			l.WithError(err).Error("Error scanning GetEarliestRemediationByIssueIDs row")
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if issueID.Valid && earliestDate.Valid {
+			result[issueID.Int64] = earliestDate.Time
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetSourceURLsByIssueIDs returns one source URL (external URL from the first IssueVariant) per issue.
+func (s *SqlDatabase) GetSourceURLsByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]string, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetSourceURLsByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64]string{}, nil
+	}
+
+	// Use MIN to get a deterministic URL per issue (grouped by issue_id).
+	query := sq.Select(
+		"IV.issuevariant_issue_id",
+		"MIN(IV.issuevariant_external_url) as source_url",
+	).
+		From("IssueVariant IV").
+		Where(sq.Eq{"IV.issuevariant_issue_id": issueIDs}).
+		Where("IV.issuevariant_deleted_at IS NULL").
+		Where("IV.issuevariant_external_url != ''").
+		GroupBy("IV.issuevariant_issue_id")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetSourceURLsByIssueIDs query")
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetSourceURLsByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetSourceURLsByIssueIDs query")
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]string)
+
+	for rows.Next() {
+		var (
+			issueID sql.NullInt64
+			url     sql.NullString
+		)
+
+		if err := rows.Scan(&issueID, &url); err != nil {
+			l.WithError(err).Error("Error scanning GetSourceURLsByIssueIDs row")
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if issueID.Valid && url.Valid {
+			result[issueID.Int64] = url.String
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetServicesByIssueIDs returns services grouped by issue ID.
+// Join path: IssueMatch -> ComponentInstance -> Service
+func (s *SqlDatabase) GetServicesByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64][]entity.ServiceResult, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetServicesByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64][]entity.ServiceResult{}, nil
+	}
+
+	query := sq.Select(
+		"IM.issuematch_issue_id",
+		"S.service_id",
+		"S.service_ccrn",
+		"S.service_domain",
+		"S.service_region",
+		"S.service_created_at",
+		"S.service_created_by",
+		"S.service_deleted_at",
+		"S.service_updated_at",
+		"S.service_updated_by",
+	).
+		From("IssueMatch IM").
+		Join("ComponentInstance CI ON IM.issuematch_component_instance_id = CI.componentinstance_id").
+		Join("Service S ON CI.componentinstance_service_id = S.service_id").
+		Where(sq.Eq{"IM.issuematch_issue_id": issueIDs}).
+		Where("IM.issuematch_deleted_at IS NULL").
+		Where("CI.componentinstance_deleted_at IS NULL").
+		Where("S.service_deleted_at IS NULL").
+		GroupBy("IM.issuematch_issue_id", "S.service_id").
+		OrderBy("S.service_ccrn ASC")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetServicesByIssueIDs query")
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetServicesByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetServicesByIssueIDs query")
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.ServiceResult)
+
+	for rows.Next() {
+		var issueID sql.NullInt64
+
+		var svcRow BaseServiceRow
+
+		if err := rows.Scan(
+			&issueID,
+			&svcRow.Id,
+			&svcRow.CCRN,
+			&svcRow.Domain,
+			&svcRow.Region,
+			&svcRow.CreatedAt,
+			&svcRow.CreatedBy,
+			&svcRow.DeletedAt,
+			&svcRow.UpdatedAt,
+			&svcRow.UpdatedBy,
+		); err != nil {
+			l.WithError(err).Error("Error scanning GetServicesByIssueIDs row")
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if !issueID.Valid {
+			continue
+		}
+
+		svc := svcRow.AsService()
+		sr := entity.ServiceResult{
+			Service: &svc,
+		}
+		result[issueID.Int64] = append(result[issueID.Int64], sr)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetSupportGroupsByIssueIDs returns support groups grouped by issue ID.
+// Join path: IssueMatch -> ComponentInstance -> Service -> SupportGroupService -> SupportGroup
+func (s *SqlDatabase) GetSupportGroupsByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64][]entity.SupportGroupResult, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetSupportGroupsByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64][]entity.SupportGroupResult{}, nil
+	}
+
+	query := sq.Select(
+		"IM.issuematch_issue_id",
+		"SG.supportgroup_id",
+		"SG.supportgroup_ccrn",
+		"SG.supportgroup_created_at",
+		"SG.supportgroup_created_by",
+		"SG.supportgroup_deleted_at",
+		"SG.supportgroup_updated_at",
+		"SG.supportgroup_updated_by",
+	).
+		From("IssueMatch IM").
+		Join("ComponentInstance CI ON IM.issuematch_component_instance_id = CI.componentinstance_id").
+		Join("Service S ON CI.componentinstance_service_id = S.service_id").
+		Join("SupportGroupService SGS ON S.service_id = SGS.supportgroupservice_service_id").
+		Join("SupportGroup SG ON SGS.supportgroupservice_support_group_id = SG.supportgroup_id").
+		Where(sq.Eq{"IM.issuematch_issue_id": issueIDs}).
+		Where("IM.issuematch_deleted_at IS NULL").
+		Where("CI.componentinstance_deleted_at IS NULL").
+		Where("S.service_deleted_at IS NULL").
+		Where("SGS.supportgroupservice_deleted_at IS NULL").
+		Where("SG.supportgroup_deleted_at IS NULL").
+		GroupBy("IM.issuematch_issue_id", "SG.supportgroup_id").
+		OrderBy("SG.supportgroup_ccrn ASC")
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetSupportGroupsByIssueIDs query")
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetSupportGroupsByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetSupportGroupsByIssueIDs query")
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64][]entity.SupportGroupResult)
+
+	for rows.Next() {
+		var issueID sql.NullInt64
+
+		var sgRow SupportGroupRow
+
+		if err := rows.Scan(
+			&issueID,
+			&sgRow.Id,
+			&sgRow.CCRN,
+			&sgRow.CreatedAt,
+			&sgRow.CreatedBy,
+			&sgRow.DeletedAt,
+			&sgRow.UpdatedAt,
+			&sgRow.UpdatedBy,
+		); err != nil {
+			l.WithError(err).Error("Error scanning GetSupportGroupsByIssueIDs row")
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if !issueID.Valid {
+			continue
+		}
+
+		sg := sgRow.AsSupportGroup()
+		sgr := entity.SupportGroupResult{
+			SupportGroup: &sg,
+		}
+		result[issueID.Int64] = append(result[issueID.Int64], sgr)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetVulnerabilityAggregatesByIssueIDs reads pre-computed severity, remediation date, and source URL
+// from the mvVulnerabilityList materialized view. This replaces 3 separate batch queries
+// (GetMaxSeverityByIssueIDs, GetEarliestRemediationByIssueIDs, GetSourceURLsByIssueIDs) with a
+// single indexed lookup when the MV is available.
+func (s *SqlDatabase) GetVulnerabilityAggregatesByIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]entity.VulnerabilityAggregate, error) {
+	l := logrus.WithFields(logrus.Fields{
+		"issueIDs": issueIDs,
+		"event":    "database.GetVulnerabilityAggregatesByIssueIDs",
+	})
+
+	if len(issueIDs) == 0 {
+		return map[int64]entity.VulnerabilityAggregate{}, nil
+	}
+
+	query := sq.Select(
+		"MVL.issue_id",
+		"MVL.max_severity",
+		"MVL.earliest_remediation_date",
+		"MVL.source_url",
+	).
+		From("mvVulnerabilityList MVL").
+		Where(sq.Eq{"MVL.issue_id": issueIDs})
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		l.WithError(err).Error("Error building GetVulnerabilityAggregatesByIssueIDs query")
+		return nil, fmt.Errorf("GetVulnerabilityAggregatesByIssueIDs: failed to build query: %w", err)
+	}
+
+	l.WithField("query", sqlStr).Debug("Executing GetVulnerabilityAggregatesByIssueIDs")
+
+	querycounter.Increment(ctx)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
+	if err != nil {
+		l.WithError(err).Error("Error executing GetVulnerabilityAggregatesByIssueIDs query")
+		return nil, fmt.Errorf("GetVulnerabilityAggregatesByIssueIDs: error executing query: %w", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			l.Warnf("error closing rows: %s", err)
+		}
+	}()
+
+	result := make(map[int64]entity.VulnerabilityAggregate, len(issueIDs))
+
+	for rows.Next() {
+		var issueID int64
+
+		var severity sql.NullString
+
+		var remediationDate sql.NullTime
+
+		var sourceURL sql.NullString
+
+		if err := rows.Scan(&issueID, &severity, &remediationDate, &sourceURL); err != nil {
+			l.WithError(err).Error("Error scanning GetVulnerabilityAggregatesByIssueIDs row")
+			return nil, fmt.Errorf("GetVulnerabilityAggregatesByIssueIDs: error scanning row: %w", err)
+		}
+
+		agg := entity.VulnerabilityAggregate{}
+		if severity.Valid {
+			agg.MaxSeverity = severity.String
+		}
+
+		if remediationDate.Valid {
+			agg.EarliestRemediationDate = &remediationDate.Time
+		}
+
+		if sourceURL.Valid {
+			agg.SourceURL = sourceURL.String
+		}
+
+		result[issueID] = agg
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetVulnerabilityAggregatesByIssueIDs: error iterating rows: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/database/mariadb/vulnerability_batch_test.go
+++ b/internal/database/mariadb/vulnerability_batch_test.go
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mariadb_test
+
+import (
+	"context"
+
+	"github.com/cloudoperators/heureka/internal/database/mariadb"
+	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("VulnerabilityBatch", Label("database", "VulnerabilityBatch"), func() {
+	var db *mariadb.SqlDatabase
+
+	var seeder *test.DatabaseSeeder
+
+	var seedCollection *test.SeedCollection
+
+	BeforeEach(func() {
+		var err error
+
+		db = dbm.NewTestSchema()
+		seeder, err = test.NewDatabaseSeeder(dbm.DbConfig())
+		Expect(err).To(BeNil(), "Database Seeder Setup should work")
+
+		seedCollection = seeder.SeedDbWithNFakeData(10)
+	})
+	AfterEach(func() {
+		dbm.TestTearDown(db)
+	})
+
+	Describe("GetMaxSeverityByIssueIDs", Label("GetMaxSeverityByIssueIDs"), func() {
+		Context("with empty issue IDs slice", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetMaxSeverityByIssueIDs(context.Background(), []int64{})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("with valid issue IDs that have issue matches", func() {
+			It("returns severity values for each issue", func() {
+				// Collect issue IDs that have issue matches
+				issueIDs := make([]int64, 0)
+
+				issueIDSet := make(map[int64]bool)
+				for _, im := range seedCollection.IssueMatchRows {
+					if !issueIDSet[im.IssueId.Int64] {
+						issueIDSet[im.IssueId.Int64] = true
+						issueIDs = append(issueIDs, im.IssueId.Int64)
+					}
+				}
+
+				result, err := db.GetMaxSeverityByIssueIDs(context.Background(), issueIDs)
+
+				By("not returning an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning results for issues that have matches", func() {
+					Expect(len(result)).To(BeNumerically(">", 0))
+				})
+
+				By("returning valid severity values", func() {
+					validValues := []string{"None", "Low", "Medium", "High", "Critical"}
+					for _, sev := range result {
+						Expect(validValues).To(ContainElement(sev))
+					}
+				})
+			})
+		})
+
+		Context("with non-existent issue IDs", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetMaxSeverityByIssueIDs(context.Background(), []int64{99999, 99998})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("GetEarliestRemediationByIssueIDs", Label("GetEarliestRemediationByIssueIDs"), func() {
+		Context("with empty issue IDs slice", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetEarliestRemediationByIssueIDs(context.Background(), []int64{})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("with valid issue IDs that have issue matches", func() {
+			It("returns the earliest remediation date for each issue", func() {
+				// Collect issue IDs that have issue matches
+				issueIDs := make([]int64, 0)
+
+				issueIDSet := make(map[int64]bool)
+				for _, im := range seedCollection.IssueMatchRows {
+					if !issueIDSet[im.IssueId.Int64] {
+						issueIDSet[im.IssueId.Int64] = true
+						issueIDs = append(issueIDs, im.IssueId.Int64)
+					}
+				}
+
+				result, err := db.GetEarliestRemediationByIssueIDs(context.Background(), issueIDs)
+
+				By("not returning an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning results for issues that have matches", func() {
+					Expect(len(result)).To(BeNumerically(">", 0))
+				})
+
+				By("returning valid dates (not zero)", func() {
+					for _, date := range result {
+						Expect(date.IsZero()).To(BeFalse())
+					}
+				})
+			})
+		})
+
+		Context("with non-existent issue IDs", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetEarliestRemediationByIssueIDs(context.Background(), []int64{99999, 99998})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("GetSourceURLsByIssueIDs", Label("GetSourceURLsByIssueIDs"), func() {
+		Context("with empty issue IDs slice", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetSourceURLsByIssueIDs(context.Background(), []int64{})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("with valid issue IDs that have issue variants", func() {
+			It("returns source URLs for issues with variants", func() {
+				// Collect issue IDs from issue variants
+				issueIDs := make([]int64, 0)
+
+				issueIDSet := make(map[int64]bool)
+				for _, iv := range seedCollection.IssueVariantRows {
+					if !issueIDSet[iv.IssueId.Int64] {
+						issueIDSet[iv.IssueId.Int64] = true
+						issueIDs = append(issueIDs, iv.IssueId.Int64)
+					}
+				}
+
+				result, err := db.GetSourceURLsByIssueIDs(context.Background(), issueIDs)
+
+				By("not returning an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				// Note: result might be empty if all variants have empty external_url
+				// But it should not error
+				By("returning a valid map (possibly empty if no URLs exist)", func() {
+					Expect(result).ToNot(BeNil())
+				})
+			})
+		})
+
+		Context("with non-existent issue IDs", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetSourceURLsByIssueIDs(context.Background(), []int64{99999, 99998})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("GetServicesByIssueIDs", Label("GetServicesByIssueIDs"), func() {
+		Context("with empty issue IDs slice", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetServicesByIssueIDs(context.Background(), []int64{})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("with valid issue IDs that have issue matches with services", func() {
+			It("returns services grouped by issue ID", func() {
+				// Collect issue IDs that have issue matches
+				issueIDs := make([]int64, 0)
+
+				issueIDSet := make(map[int64]bool)
+				for _, im := range seedCollection.IssueMatchRows {
+					if !issueIDSet[im.IssueId.Int64] {
+						issueIDSet[im.IssueId.Int64] = true
+						issueIDs = append(issueIDs, im.IssueId.Int64)
+					}
+				}
+
+				result, err := db.GetServicesByIssueIDs(context.Background(), issueIDs)
+
+				By("not returning an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				By("returning services for at least some issues", func() {
+					Expect(len(result)).To(BeNumerically(">", 0))
+				})
+
+				By("returning services with valid CCRNs", func() {
+					for _, services := range result {
+						for _, sr := range services {
+							Expect(sr.Service).ToNot(BeNil())
+							Expect(sr.Service.CCRN).ToNot(BeEmpty())
+						}
+					}
+				})
+
+				By("returning services ordered by CCRN", func() {
+					for _, services := range result {
+						if len(services) > 1 {
+							for i := 1; i < len(services); i++ {
+								Expect(services[i].Service.CCRN >= services[i-1].Service.CCRN).To(BeTrue())
+							}
+						}
+					}
+				})
+			})
+		})
+
+		Context("with non-existent issue IDs", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetServicesByIssueIDs(context.Background(), []int64{99999, 99998})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("GetSupportGroupsByIssueIDs", Label("GetSupportGroupsByIssueIDs"), func() {
+		Context("with empty issue IDs slice", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetSupportGroupsByIssueIDs(context.Background(), []int64{})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("with valid issue IDs", func() {
+			It("returns support groups grouped by issue ID (may be empty if no links exist)", func() {
+				// Collect issue IDs that have issue matches
+				issueIDs := make([]int64, 0)
+
+				issueIDSet := make(map[int64]bool)
+				for _, im := range seedCollection.IssueMatchRows {
+					if !issueIDSet[im.IssueId.Int64] {
+						issueIDSet[im.IssueId.Int64] = true
+						issueIDs = append(issueIDs, im.IssueId.Int64)
+					}
+				}
+
+				result, err := db.GetSupportGroupsByIssueIDs(context.Background(), issueIDs)
+
+				By("not returning an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				// Support groups might not be linked to all issues
+				By("returning a valid result map", func() {
+					Expect(result).ToNot(BeNil())
+				})
+
+				By("returning support groups with valid CCRNs when present", func() {
+					for _, groups := range result {
+						for _, sgr := range groups {
+							Expect(sgr.SupportGroup).ToNot(BeNil())
+							Expect(sgr.SupportGroup.CCRN).ToNot(BeEmpty())
+						}
+					}
+				})
+
+				By("returning support groups ordered by CCRN", func() {
+					for _, groups := range result {
+						if len(groups) > 1 {
+							for i := 1; i < len(groups); i++ {
+								Expect(groups[i].SupportGroup.CCRN >= groups[i-1].SupportGroup.CCRN).To(BeTrue())
+							}
+						}
+					}
+				})
+			})
+		})
+
+		Context("with non-existent issue IDs", func() {
+			It("returns an empty map", func() {
+				result, err := db.GetSupportGroupsByIssueIDs(context.Background(), []int64{99999, 99998})
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/internal/database/querycounter/querycounter.go
+++ b/internal/database/querycounter/querycounter.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package querycounter
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type contextKey struct{}
+
+// Init stores a new atomic counter in the context and returns the new context.
+// Call this once per request (e.g., in middleware).
+func Init(ctx context.Context) context.Context {
+	counter := new(atomic.Int64)
+	return context.WithValue(ctx, contextKey{}, counter)
+}
+
+// Increment atomically increments the query counter stored in ctx.
+// If no counter was initialized (e.g., in tests without middleware), this is a no-op.
+func Increment(ctx context.Context) {
+	if c := fromContext(ctx); c != nil {
+		c.Add(1)
+	}
+}
+
+// GetQueryCount returns the current value of the query counter from the context.
+// Returns 0 if no counter was initialized.
+func GetQueryCount(ctx context.Context) int {
+	if c := fromContext(ctx); c != nil {
+		return int(c.Load())
+	}
+
+	return 0
+}
+
+func fromContext(ctx context.Context) *atomic.Int64 {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return nil
+	}
+
+	return v.(*atomic.Int64)
+}

--- a/internal/database/querycounter/querycounter_benchmark_test.go
+++ b/internal/database/querycounter/querycounter_benchmark_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package querycounter_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+)
+
+func BenchmarkIncrement(b *testing.B) {
+	ctx := querycounter.Init(context.Background())
+
+	b.ResetTimer()
+
+	for range b.N {
+		querycounter.Increment(ctx)
+	}
+}
+
+func BenchmarkIncrement_NoInit(b *testing.B) {
+	ctx := context.Background()
+
+	b.ResetTimer()
+
+	for range b.N {
+		querycounter.Increment(ctx)
+	}
+}
+
+func BenchmarkGetQueryCount(b *testing.B) {
+	ctx := querycounter.Init(context.Background())
+	querycounter.Increment(ctx)
+	b.ResetTimer()
+
+	for range b.N {
+		querycounter.GetQueryCount(ctx)
+	}
+}

--- a/internal/database/querycounter/querycounter_test.go
+++ b/internal/database/querycounter/querycounter_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package querycounter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cloudoperators/heureka/internal/database/querycounter"
+)
+
+func TestGetQueryCount_ReturnsZeroWithoutInit(t *testing.T) {
+	ctx := context.Background()
+	if got := querycounter.GetQueryCount(ctx); got != 0 {
+		t.Errorf("GetQueryCount() = %d, want 0", got)
+	}
+}
+
+func TestIncrement_NoOpWithoutInit(t *testing.T) {
+	ctx := context.Background()
+	// Should not panic
+	querycounter.Increment(ctx)
+
+	if got := querycounter.GetQueryCount(ctx); got != 0 {
+		t.Errorf("GetQueryCount() = %d, want 0", got)
+	}
+}
+
+func TestInitAndIncrement(t *testing.T) {
+	ctx := querycounter.Init(context.Background())
+
+	if got := querycounter.GetQueryCount(ctx); got != 0 {
+		t.Fatalf("initial GetQueryCount() = %d, want 0", got)
+	}
+
+	querycounter.Increment(ctx)
+	querycounter.Increment(ctx)
+	querycounter.Increment(ctx)
+
+	if got := querycounter.GetQueryCount(ctx); got != 3 {
+		t.Errorf("GetQueryCount() = %d, want 3", got)
+	}
+}
+
+func TestIncrement_ConcurrentSafety(t *testing.T) {
+	ctx := querycounter.Init(context.Background())
+
+	const goroutines = 100
+
+	const incrementsPerGoroutine = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+
+			for range incrementsPerGoroutine {
+				querycounter.Increment(ctx)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expected := goroutines * incrementsPerGoroutine
+	if got := querycounter.GetQueryCount(ctx); got != expected {
+		t.Errorf("GetQueryCount() = %d, want %d", got, expected)
+	}
+}
+
+func TestSeparateContextsAreIndependent(t *testing.T) {
+	ctx1 := querycounter.Init(context.Background())
+	ctx2 := querycounter.Init(context.Background())
+
+	querycounter.Increment(ctx1)
+	querycounter.Increment(ctx1)
+	querycounter.Increment(ctx2)
+
+	if got := querycounter.GetQueryCount(ctx1); got != 2 {
+		t.Errorf("ctx1 GetQueryCount() = %d, want 2", got)
+	}
+
+	if got := querycounter.GetQueryCount(ctx2); got != 1 {
+		t.Errorf("ctx2 GetQueryCount() = %d, want 1", got)
+	}
+}

--- a/internal/e2e/issue_counts_query_test.go
+++ b/internal/e2e/issue_counts_query_test.go
@@ -49,6 +49,8 @@ var _ = Describe("Getting IssueCounts via API", Label("e2e", "IssueCounts"), fun
 			Expect(err).To(BeNil(), "Seeding should work")
 			err = seeder.RefreshCountIssueRatings()
 			Expect(err).To(BeNil(), "Refresh should work")
+			err = seeder.RefreshServiceIssueCounters()
+			Expect(err).To(BeNil(), "Refresh service issue counters should work")
 		})
 		Context("and a filter is used", func() {
 			It("correct filters by support group", func() {

--- a/internal/e2e/vulnerability_query_test.go
+++ b/internal/e2e/vulnerability_query_test.go
@@ -119,6 +119,8 @@ var _ = Describe("Getting Vulnerabilities via API", Label("e2e", "Vulnerabilitie
 			}
 			err = seeder.RefreshCountIssueRatings()
 			Expect(err).To(BeNil())
+			err = seeder.RefreshMvVulnerabilityList()
+			Expect(err).To(BeNil())
 		})
 
 		It("returns the expected content and the expected PageInfo", func() {

--- a/internal/entity/issue.go
+++ b/internal/entity/issue.go
@@ -79,6 +79,7 @@ type IssueFilter struct {
 	IssueMatchDiscoveryDate         *TimeFilter       `json:"issue_match_discovery_date"`
 	IssueMatchTargetRemediationDate *TimeFilter       `json:"issue_match_target_remediation_date"`
 	Unique                          bool              `json:"unique"`
+	UseMvVulnerabilityList          bool              `json:"use_mv_vulnerability_list"`
 	Status                          IssueStatus       `json:"status"`
 	State                           []StateFilterType `json:"state"`
 }
@@ -157,4 +158,22 @@ type IssueList struct {
 type IssueListOptions struct {
 	ListOptions
 	ShowIssueTypeCounts bool
+}
+
+// VulnerabilityAggregate holds pre-computed aggregate data from mvVulnerabilityList.
+type VulnerabilityAggregate struct {
+	MaxSeverity             string
+	EarliestRemediationDate *time.Time
+	SourceURL               string
+}
+
+// VulnerabilityResult is a lightweight struct for batch-loaded vulnerability data
+// from the mvVulnerabilityList materialized view joined with Issue.
+type VulnerabilityResult struct {
+	IssueID                 int64
+	PrimaryName             string
+	Description             string
+	MaxSeverity             string
+	EarliestRemediationDate *time.Time
+	SourceURL               string
 }

--- a/internal/entity/issue.go
+++ b/internal/entity/issue.go
@@ -76,6 +76,7 @@ type IssueFilter struct {
 	Search                          []*string         `json:"search"`
 	IssueMatchStatus                []*string         `json:"issue_match_status"`
 	IssueMatchSeverity              []*string         `json:"issue_match_severity"`
+	MvSeverity                      []*string         `json:"mv_severity"`
 	IssueMatchDiscoveryDate         *TimeFilter       `json:"issue_match_discovery_date"`
 	IssueMatchTargetRemediationDate *TimeFilter       `json:"issue_match_target_remediation_date"`
 	Unique                          bool              `json:"unique"`


### PR DESCRIPTION
## Summary

Eliminates N+1 query problems and expensive base list queries across all main GraphQL queries used by the Heureka UI, bringing every page load to sub-second response times.

### Performance Results (production dataset: 276K issues, 10M IssueMatches, 138 services)

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| **GetVulnerabilities** (unfiltered, 20 items) | **73s** | **450ms** | **162×** |
| **GetVulnerabilities** (severity + service filter) | **3.4s** | **40ms** | **85×** |
| **GetImages** (service detail, nested vulns) | **5.4s** | **260ms** | **21×** |
| **GetServices** (20 items, all nested fields) | **600ms** | **14ms** | **43×** |
| GetVulnerabilities (service filter only) | 3.4s | 500ms | 7× |
| GetVulnerabilities (search) | 400ms | 220ms | 2× |
| Image vulnerability search | 300ms | 70ms | 4× |

## Problem

Three distinct performance problems:

1. **N+1 queries**: Each of 20 results individually resolved child fields (severity, services, supportGroups, etc.) — 101 DB calls per page load for vulnerabilities.

2. **Expensive base list query**: The VulnerabilityBaseResolver triggered a RIGHT JOIN on the 10M-row IssueMatch table with GROUP BY + ORDER BY. `GetAllIssueCursors` (pagination) fetched ALL 12K matching cursors using the same expensive JOINs — ~50s alone.

3. **Filtered queries still slow**: Even after the MV, filtering by severity or service fell back to IssueMatch because the code required live IssueMatch data for those filters.

## Solution

### Part 1: Batch Pre-load (all queries)

Base resolvers now:
1. Check `GetPreloads(ctx)` for requested nested fields
2. Extract parent IDs from results
3. Fire concurrent batch queries via `errgroup`
4. Attach results to model structs
5. Child resolvers short-circuit with nil-check guards (filter-aware — falls through when user applies filters)

### Part 2: `mvVulnerabilityList` (12K rows)

Pre-computes which issues are active vulnerabilities (type=Vulnerability, has ≥1 IssueMatch with status=new), with:
- `max_severity` — MAX(issuematch_rating) per issue
- `earliest_remediation_date` — MIN(target_remediation_date)
- `source_url` — first external URL from IssueVariant

The VulnerabilityBaseResolver INNER JOINs this instead of RIGHT JOINing 10M IssueMatch rows. Severity filter uses `MVL.max_severity` directly.

### Part 3: `mvVulnerabilityService` (92K rows)

Junction table mapping `(service_id, issue_id)` — pre-computes which services each vulnerability affects. Eliminates the `IM → CI → S` join chain for service/supportGroup filters.

With both MVs, the resolver **always** uses the MV path — no fallback to IssueMatch for any UI filter combination.

### Part 4: Image-Level Vulnerability Batch Pre-load

For service detail pages, `ImageBaseResolver` batch-loads vulnerabilities for all images in a single query via `CVI → CV → Issue → mvVulnerabilityList`. The resolver guard only uses pre-loaded data when no user-supplied filter or pagination cursor is active.

## Architecture

```
┌─────────────────────────────────────────────────────────┐
│ VulnerabilityBaseResolver                                │
│                                                         │
│  f.UseMvVulnerabilityList = true  (always)              │
│  f.MvSeverity = filter.Severity   (MVL.max_severity)    │
│  f.ServiceCCRN = filter.Service   (via MVS junction)    │
│                                                         │
│  Query: Issue I                                         │
│         JOIN mvVulnerabilityList MVL                     │
│         JOIN mvVulnerabilityService MVS (if service/sg)  │
│         JOIN Service S (if service filter)               │
│                                                         │
│  No IssueMatch table touched.                           │
└─────────────────────────────────────────────────────────┘
```

## MV Refresh

Both MVs refresh via MariaDB event scheduler (same pattern as existing `mvServiceIssueCounts`):
- `refresh_mvVulnerabilityList` — every 200 minutes
- `refresh_mvVulnerabilityService` — every 200 minutes (runs after VulnerabilityList)

Uses atomic swap pattern: create tmp → populate → RENAME → drop old.

## Changes

### New: Materialized Views
- **`20260610120000_add_mv_vulnerability_list`** — 12K rows, pre-computed active vulnerabilities with aggregates
- **`20260610140000_add_mv_vulnerability_service`** — 92K rows, junction table for service-scoped queries

### New: Query Counter Middleware (`internal/database/querycounter/`)
- Context-based atomic counter, logs `db_query_count` per request

### New: Batch DB Methods
- **Services**: `GetOwnersByServiceIDs`, `GetSupportGroupsByServiceIDs`, `GetIssueCountsByServiceIDs`
- **Vulnerabilities**: `GetVulnerabilityAggregatesByIssueIDs` (MV-backed), `GetServicesByIssueIDs`, `GetSupportGroupsByIssueIDs`
- **Images**: `GetVersionsByComponentIDs`, `GetIssueCountsByComponentIDs`, `GetVulnerabilitiesByComponentIDs`, `GetVulnerabilityCountsByComponentIDs`

### Modified: Query Builder (`issue.go`)
- New FilterProperty: `MVL.max_severity = ?` for MV-based severity filter
- New JoinDefs: `MVS`, `S with MVS`, `SGS with MVS`, `SG with MVS` for service/supportGroup via junction table
- Old IM_LJ join chain guarded with `!f.UseMvVulnerabilityList`

### Modified: Resolvers
- `VulnerabilityBaseResolver` — always MV path, severity mapped to `MvSeverity`
- `ImageBaseResolver` — batch pre-load for vulnerabilities via MV
- `ServiceBaseResolver` — batch pre-load with errgroup
- Child resolvers — filter-aware nil-check guards

## Design Decisions

1. **Always-MV for vulnerability queries** — No conditional fallback. The MV handles all UI filter combinations (severity, service, supportGroup, search, unfiltered). Only parent-scoped queries (Image→Vulnerabilities) use IssueMatch since they need CVI joins.
2. **Junction table over extended MV** — A separate `mvVulnerabilityService` table (92K rows) is cleaner than adding service_id to mvVulnerabilityList (which would explode to 92K rows and lose the PK-on-issue_id optimization).
3. **Subquery aliases for ambiguity** — MVL uses `issue_id AS mvl_issue_id`, MVS uses `issue_id AS mvs_issue_id` to avoid ORDER BY ambiguity with `I.issue_id`.
4. **Filter-aware resolver guards** — Pre-loaded data only used when no user filter/pagination is active, preventing stale results.
5. **Graceful degradation** — If batch queries fail, child resolvers fall through to per-item resolution.

## Testing

- ✅ Full `go build ./internal/...` compiles clean
- ✅ Verified with production dataset (276K issues, 10M IssueMatches)
- ✅ All filter combinations tested (unfiltered, severity, service, severity+service, search)
- ✅ Service detail page: 5.4s → 260ms
- ✅ Filtered vulnerabilities: 3.4s → 40ms
- ✅ Pagination fallback works correctly
