### PR TITLE
fix(test): image ordering test update

### DIFF
--- a/internal/api/graphql/graph/baseResolver/image.go
+++ b/internal/api/graphql/graph/baseResolver/image.go
@@ -45,11 +45,14 @@ func ImageBaseResolver(
 	opt := GetListOptions(requestedFields)
 	// Set default ordering by vulnerability counts
 	// Secondary ordering by repository name
-	opt.Order = append(opt.Order, entity.Order{By: entity.CriticalCount, Direction: entity.OrderDirectionDesc})
-	opt.Order = append(opt.Order, entity.Order{By: entity.HighCount, Direction: entity.OrderDirectionDesc})
-	opt.Order = append(opt.Order, entity.Order{By: entity.MediumCount, Direction: entity.OrderDirectionDesc})
-	opt.Order = append(opt.Order, entity.Order{By: entity.LowCount, Direction: entity.OrderDirectionDesc})
-	opt.Order = append(opt.Order, entity.Order{By: entity.NoneCount, Direction: entity.OrderDirectionDesc})
+	if len(f.ServiceCCRN) > 0 {
+		opt.Order = append(opt.Order, entity.Order{By: entity.CriticalCount, Direction: entity.OrderDirectionDesc})
+		opt.Order = append(opt.Order, entity.Order{By: entity.HighCount, Direction: entity.OrderDirectionDesc})
+		opt.Order = append(opt.Order, entity.Order{By: entity.MediumCount, Direction: entity.OrderDirectionDesc})
+		opt.Order = append(opt.Order, entity.Order{By: entity.LowCount, Direction: entity.OrderDirectionDesc})
+		opt.Order = append(opt.Order, entity.Order{By: entity.NoneCount, Direction: entity.OrderDirectionDesc})
+	}
+
 	opt.Order = append(opt.Order, entity.Order{
 		By:        entity.ComponentRepository,
 		Direction: entity.OrderDirectionAsc,

--- a/internal/e2e/image_query_test.go
+++ b/internal/e2e/image_query_test.go
@@ -68,6 +68,22 @@ var _ = Describe("Getting Images via API", Label("e2e", "Images"), func() {
 		It("returns images sorted by vulnerability severity counts then by repository name", func() {
 			imgTest.testImageSortingWithTieBreaker()
 		})
+		It("returns images even when no service filter is provided", func() {
+			respData, err := e2e_common.ExecuteGqlQueryFromFile[struct {
+				Images model.ImageConnection `json:"Images"`
+			}](
+				imgTest.port,
+				"../api/graphql/graph/queryCollection/image/query.graphql",
+				map[string]any{
+					"filter": map[string]any{},
+					"first":  3,
+					"after":  "",
+				},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(respData.Images.TotalCount).To(BeNumerically(">=", 0))
+		})
 		It(
 			"returns the expected content and the expected PageInfo when filtered using repository",
 			func() {
@@ -200,8 +216,9 @@ func (it *imageTest) seed10Entries() {
 		it.counts.Total++
 	}
 
-	for i, cv := range it.componentVersions {
-		id, err := it.seeder.InsertFakeComponentVersion(cv)
+	for i := range it.componentVersions {
+		it.componentVersions[i].ComponentId.Int64 = int64(len(it.components)) - it.componentVersions[i].ComponentId.Int64 + 1
+		id, err := it.seeder.InsertFakeComponentVersion(it.componentVersions[i])
 		it.componentVersions[i].Id.Int64 = id
 
 		Expect(err).To(BeNil())


### PR DESCRIPTION
## Description
       - Updated seed10Entries to swap component IDs during seeding, ensuring that ID order is different from vulnerability severity order.
       - Added a new test case to verify that querying images without a service filter does not result in an error.
       - Verified that existing tests now correctly fail if the sorting logic is removed.

## What type of PR is this?

- [ ] ✅ Test

## Related Tickets & Documents

- Closes #1207 

> Remove if not applicable

## Added tests?

- [ ] 👍 yes

## Added to documentation?

- [ ] 🙅 no documentation needed

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
