### PR TITLE
fix(graphql): resolve 0-vulnerability detail view for parent-scoped image queries

### DIFF
--- a/internal/api/graphql/graph/baseResolver/vulnerability.go
+++ b/internal/api/graphql/graph/baseResolver/vulnerability.go
@@ -70,6 +70,10 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		// When resolving vulnerabilities for a specific parent (Image/ImageVersion),
 		// use the live IssueMatch join path since the ComponentVersionIssue join
 		// already scopes to the relevant issues.
+		// Clear service/supportGroup filters — the parent component scope is sufficient
+		// and these filters would activate incompatible join paths.
+		f.ServiceCCRN = nil
+		f.SupportGroupCCRN = nil
 		f.HasIssueMatches = true
 		f.IssueMatchStatus = []*string{new(entity.IssueMatchStatusValuesNew.String())}
 		f.IssueMatchSeverity = lo.Map(

--- a/internal/api/graphql/graph/baseResolver/vulnerability.go
+++ b/internal/api/graphql/graph/baseResolver/vulnerability.go
@@ -72,6 +72,8 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		// already scopes to the relevant issues.
 		// Clear service/supportGroup filters — the parent component scope is sufficient
 		// and these filters would activate incompatible join paths.
+		filter.Service = nil
+		filter.SupportGroup = nil
 		f.ServiceCCRN = nil
 		f.SupportGroupCCRN = nil
 		f.HasIssueMatches = true

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -163,11 +163,13 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			},
 		},
 		{
-			Name:      "CVI",
-			Type:      LeftJoin,
-			Table:     "ComponentVersionIssue CVI",
-			On:        "I.issue_id = CVI.componentversionissue_issue_id",
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.ComponentVersionId) > 0 },
+			Name:  "CVI",
+			Type:  LeftJoin,
+			Table: "ComponentVersionIssue CVI",
+			On:    "I.issue_id = CVI.componentversionissue_issue_id",
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				return len(f.ComponentVersionId) > 0 || len(f.ComponentId) > 0
+			},
 		},
 		{
 			Name:      "CV using CVI",

--- a/internal/e2e/image_query_test.go
+++ b/internal/e2e/image_query_test.go
@@ -118,6 +118,72 @@ var _ = Describe("Getting Images via API", Label("e2e", "Images"), func() {
 				Expect(*respData.Images.Counts).To(Equal(counts))
 			},
 		)
+		It(
+			"returns vulnerabilities for an image when using service filter and vulnerability severity filter",
+			func() {
+				// This test exercises the VulnerabilityBaseResolver fallthrough path
+				// (not the batch preload) by passing a vulnerability filter, which sets
+				// hasUserFilter=true in the image resolver and bypasses pre-loaded data.
+				// Regression test: service filter must not break the CVI→CV join chain
+				// needed for ComponentId-scoped vulnerability queries.
+				service := imgTest.services[0]
+
+				query := `query ($imgFilter: ImageFilter, $vulFilter: VulnerabilityFilter, $first: Int) {
+					Images(first: $first, filter: $imgFilter) {
+						edges {
+							node {
+								id
+								vulnerabilities(filter: $vulFilter) {
+									totalCount
+									edges {
+										node {
+											id
+											severity
+											name
+										}
+									}
+								}
+							}
+						}
+					}
+				}`
+
+				respData, err := e2e_common.ExecuteGqlQuery[struct {
+					Images model.ImageConnection `json:"Images"`
+				}](
+					imgTest.port,
+					query,
+					map[string]any{
+						"imgFilter": map[string]any{
+							"service": []string{service.CCRN.String},
+						},
+						"vulFilter": map[string]any{
+							"severity": []string{"Critical"},
+						},
+						"first": 5,
+					},
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(respData.Images.Edges)).To(BeNumerically(">", 0), "should return at least one image")
+
+				// At least one image should have vulnerabilities with Critical severity
+				hasVulns := false
+
+				for _, edge := range respData.Images.Edges {
+					if edge.Node.Vulnerabilities != nil && len(edge.Node.Vulnerabilities.Edges) > 0 {
+						hasVulns = true
+
+						for _, vuln := range edge.Node.Vulnerabilities.Edges {
+							Expect(vuln.Node.Severity).ToNot(BeNil())
+							Expect(vuln.Node.Severity.String()).To(Equal("Critical"))
+						}
+					}
+				}
+
+				Expect(hasVulns).To(BeTrue(), "at least one image should have Critical vulnerabilities")
+			},
+		)
 	})
 })
 
@@ -225,6 +291,9 @@ func (it *imageTest) seed10Entries() {
 	}
 
 	err = it.seeder.RefreshComponentVulnerabilityCounts()
+	Expect(err).To(BeNil())
+
+	err = it.seeder.RefreshMvVulnerabilityList()
 	Expect(err).To(BeNil())
 }
 


### PR DESCRIPTION
## Problem

When clicking an image in the UI (detail view), the vulnerability list shows **0 vulnerabilities** even though the image list view shows a non-zero vulnerability count.

This is a **pre-existing bug** introduced during the [JoinDefs refactor (`3349103`)](https://github.com/cloudoperators/heureka/commit/3349103), not a regression from any recent PR. It became *visible* after the batch pre-load work ([`d1e6ea7`](https://github.com/cloudoperators/heureka/commit/d1e6ea7)) because that PR removed a fallback path that was silently returning incorrect (but non-empty) data.

## Root Cause

The image detail vulnerability resolver calls `VulnerabilityBaseResolver` with `parent=ImageNodeName`, which sets `f.ComponentId` to scope issues to the relevant component. This requires two joins to activate:

1. **`CVI`** — `LEFT JOIN ComponentVersionIssue CVI` (links issues to component versions)
2. **`CV using CVI`** — `LEFT JOIN ComponentVersion CV` (links component versions to the component, enabling the `WHERE CV.componentversion_component_id = ?` filter)

**Bug 1: CVI join condition too narrow** ([`issue.go:165`](https://github.com/cloudoperators/heureka/blob/1718f58/internal/database/mariadb/issue.go#L165))

The original hand-written code activated CVI for both `ComponentVersionId` and `ComponentId`:
```go
if len(filter.ComponentVersionId) > 0 || len(filter.ComponentId) > 0 {
```

The JoinDefs refactor ([`3349103`](https://github.com/cloudoperators/heureka/commit/3349103)) lost the `ComponentId` check:
```go
Condition: func(f *entity.IssueFilter, _ *Order) bool { return len(f.ComponentVersionId) > 0 },
```

**Bug 2: Service filter poisons `CV using CVI` condition** ([`issue.go:178`](https://github.com/cloudoperators/heureka/blob/1718f58/internal/database/mariadb/issue.go#L178))

The `CV using CVI` join has an intentional guard — it only activates when **no service/supportGroup filter** is set (to avoid conflicting with the alternative `CV → CI → S` join path):
```go
Condition: func(f *entity.IssueFilter, _ *Order) bool {
    return len(f.ComponentId) > 0 && (len(f.ServiceCCRN) == 0 && ...)
},
```

The [image resolver](https://github.com/cloudoperators/heureka/blob/d1e6ea7/internal/api/graphql/graph/resolver/image.go#L105) propagates the root image filter's service CCRN into the vulnerability sub-query:
```go
filter.Service = append(filter.Service, imageFilter.Service...)
```

This causes `f.ServiceCCRN` to be populated, so `CV using CVI` evaluates to `false` — even though the service filter is semantically irrelevant at this point (the `ComponentId` already scopes results to the correct image).

## Fix

1. **Extend CVI join condition** to also fire for `ComponentId`:
   ```go
   Condition: func(f *entity.IssueFilter, _ *Order) bool {
       return len(f.ComponentVersionId) > 0 || len(f.ComponentId) > 0
   },
   ```

2. **Clear `ServiceCCRN` and `SupportGroupCCRN`** in `VulnerabilityBaseResolver` when a parent is set — the component scope is sufficient, and these filters would prevent the required join path from activating:
   ```go
   f.ServiceCCRN = nil
   f.SupportGroupCCRN = nil
   ```

Both fixes are required together: fix 1 activates the CVI join (issue → component version junction), fix 2 allows the CV join to activate on top of it (junction → component, where the `ComponentId` WHERE clause lives).

## Why existing tests didn't catch this

The existing image e2e test uses [`query.graphql`](https://github.com/cloudoperators/heureka/blob/1718f58/internal/api/graphql/graph/queryCollection/image/query.graphql) which requests `vulnerabilities` **without** a `VulnerabilityFilter`. Before the batch pre-load PR, the broken CVI path meant the query fell through to the IssueMatch RIGHT JOIN — which returned vulnerabilities from *all* images (wrong data, but non-empty). The test only asserted field presence ("severity is not nil"), not correctness ("these are the right vulnerabilities for this image"), so it passed.

## E2e test added

New test case exercises the exact bug path: queries images with a **service filter** and a **severity filter** on vulnerabilities. The severity filter forces `hasUserFilter=true` in the image resolver, bypassing the batch preload cache and hitting `VulnerabilityBaseResolver` directly with a parent + service CCRN — the combination that triggered the bug.

## Changes

- [`internal/database/mariadb/issue.go`](https://github.com/cloudoperators/heureka/blob/fix/image-vulnerability-detail-view/internal/database/mariadb/issue.go) — extend CVI join condition
- [`internal/api/graphql/graph/baseResolver/vulnerability.go`](https://github.com/cloudoperators/heureka/blob/fix/image-vulnerability-detail-view/internal/api/graphql/graph/baseResolver/vulnerability.go) — clear service/SG filters for parent-scoped queries
- [`internal/e2e/image_query_test.go`](https://github.com/cloudoperators/heureka/blob/fix/image-vulnerability-detail-view/internal/e2e/image_query_test.go) — regression test + MVL refresh in seed
