### PR TITLE
fix(db): resolve vulnerability count/detail mismatch for service-scoped images

### DIFF
--- a/internal/api/graphql/graph/baseResolver/vulnerability.go
+++ b/internal/api/graphql/graph/baseResolver/vulnerability.go
@@ -70,12 +70,8 @@ func VulnerabilityBaseResolver(app app.Heureka, ctx context.Context,
 		// When resolving vulnerabilities for a specific parent (Image/ImageVersion),
 		// use the live IssueMatch join path since the ComponentVersionIssue join
 		// already scopes to the relevant issues.
-		// Clear service/supportGroup filters — the parent component scope is sufficient
-		// and these filters would activate incompatible join paths.
-		filter.Service = nil
-		filter.SupportGroup = nil
-		f.ServiceCCRN = nil
-		f.SupportGroupCCRN = nil
+		// Keep the service/supportGroup filters — the DB layer handles dual scoping
+		// via the CVI path for ComponentId and the IM→CI path for service filtering.
 		f.HasIssueMatches = true
 		f.IssueMatchStatus = []*string{new(entity.IssueMatchStatusValuesNew.String())}
 		f.IssueMatchSeverity = lo.Map(

--- a/internal/database/mariadb/issue.go
+++ b/internal/database/mariadb/issue.go
@@ -33,6 +33,22 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 		NewFilterProperty("I.issue_id = ?", func(filter *entity.IssueFilter) any { return filter.Id }),
 		NewFilterProperty("IM.issuematch_status = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchStatus }),
 		NewFilterProperty("IM.issuematch_rating = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchSeverity }),
+		// Exclude soft-deleted IssueMatches when the IM table is joined.
+		// The IM join (IM_RJ or IM_LJ) activates when HasIssueMatches or IssueMatchStatus is set.
+		NewCustomFilterProperty(
+			WrapBuilder(func(vals []bool) string {
+				if len(vals) > 0 && vals[0] {
+					return "IM.issuematch_deleted_at IS NULL"
+				}
+				return ""
+			}),
+			func(filter *entity.IssueFilter) any {
+				if filter.HasIssueMatches || len(filter.IssueMatchStatus) > 0 || len(filter.IssueMatchId) > 0 || len(filter.IssueMatchSeverity) > 0 {
+					return []bool{true}
+				}
+				return []bool{}
+			},
+		),
 		NewFilterProperty("MVL.max_severity = ?", func(filter *entity.IssueFilter) any { return filter.MvSeverity }),
 		NewFilterProperty("IM.issuematch_id = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchId }),
 		NewFilterProperty("CVI.componentversionissue_component_version_id = ?", func(filter *entity.IssueFilter) any { return filter.ComponentVersionId }),
@@ -42,6 +58,20 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 		NewFilterProperty("IV.issuevariant_repository_id = ?", func(filter *entity.IssueFilter) any { return filter.IssueRepositoryId }),
 		NewFilterProperty("SG.supportgroup_ccrn = ?", func(filter *entity.IssueFilter) any { return filter.SupportGroupCCRN }),
 		NewFilterProperty("CV.componentversion_component_id = ?", func(filter *entity.IssueFilter) any { return filter.ComponentId }),
+		// When HasIssueMatches is set with ComponentId, restrict the IM path to only
+		// include IssueMatches whose ComponentInstance belongs to a ComponentVersion
+		// of the target component. Without this, IssueMatches from OTHER components
+		// in the same service would leak through.
+		// Self-contained subquery on IM — does not require CI to be joined.
+		NewFilterProperty(
+			"IM.issuematch_component_instance_id IN (SELECT ci.componentinstance_id FROM ComponentInstance ci JOIN ComponentVersion cv ON ci.componentinstance_component_version_id = cv.componentversion_id WHERE cv.componentversion_component_id = ?)",
+			func(filter *entity.IssueFilter) any {
+				if filter.HasIssueMatches {
+					return filter.ComponentId
+				}
+				return []int64{}
+			},
+		),
 		NewNFilterProperty(
 			"IV.issuevariant_secondary_name LIKE Concat('%',?,'%') OR I.issue_primary_name LIKE Concat('%',?,'%')",
 			func(filter *entity.IssueFilter) any { return filter.Search },
@@ -114,7 +144,8 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			On:        "CI.componentinstance_component_version_id = CV.componentversion_id",
 			DependsOn: []string{"CI with IM_LJ"},
 			Condition: func(f *entity.IssueFilter, _ *Order) bool {
-				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList
+				// Only activate when NOT using IM_RJ path — otherwise CV comes from CVI path
+				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList && !f.HasIssueMatches
 			},
 		},
 		{
@@ -123,8 +154,11 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			Table:     "Service S",
 			On:        "CI.componentinstance_service_id = S.service_id",
 			DependsOn: []string{"CI with IM_RJ"},
-			Condition: func(f *entity.IssueFilter, _ *Order) bool { return f.AllServices },
-		}, // Looks like this case is not used because of mv_vulnerabilities
+			Condition: func(f *entity.IssueFilter, _ *Order) bool {
+				// Activate for service CCRN filtering when IM_RJ is the active path
+				return f.HasIssueMatches && len(f.ServiceCCRN) > 0 || f.AllServices
+			},
+		},
 		{
 			Name:      "S with IM_LJ",
 			Type:      LeftJoin,
@@ -132,7 +166,8 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			On:        "CI.componentinstance_service_id = S.service_id",
 			DependsOn: []string{"CI with IM_LJ"},
 			Condition: func(f *entity.IssueFilter, _ *Order) bool {
-				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList
+				// Only activate when NOT using IM_RJ path
+				return len(f.ServiceCCRN) > 0 && !f.UseMvVulnerabilityList && !f.HasIssueMatches
 			},
 		},
 		{
@@ -178,7 +213,11 @@ var issueObject = DbObject[*entity.Issue, *entity.IssueFilter, entity.IssueResul
 			On:        "CVI.componentversionissue_component_version_id = CV.componentversion_id",
 			DependsOn: []string{"CVI"},
 			Condition: func(f *entity.IssueFilter, _ *Order) bool {
-				return len(f.ComponentId) > 0 && (len(f.ServiceId) == 0 && len(f.ServiceCCRN) == 0 && len(f.SupportGroupCCRN) == 0 && !f.AllServices)
+				// Activate when ComponentId is set AND the ServiceCCRN path won't create
+				// a conflicting CV alias. When HasIssueMatches is true, service filtering
+				// goes through IM_RJ→CI→S (not IM_LJ→CI→CV), so no alias collision.
+				noConflictingServicePath := len(f.ServiceCCRN) == 0 || f.HasIssueMatches
+				return len(f.ComponentId) > 0 && noConflictingServicePath && len(f.SupportGroupCCRN) == 0 && !f.AllServices
 			},
 		},
 		{

--- a/internal/database/mariadb/migrations/20260618100000_fix_mv_single_component_use_issuematch_rating.down.sql
+++ b/internal/database/mariadb/migrations/20260618100000_fix_mv_single_component_use_issuematch_rating.down.sql
@@ -1,0 +1,65 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Revert: restore the issuevariant_rating-based procedure
+
+DROP PROCEDURE IF EXISTS refresh_mvSingleComponentByServiceVulnerabilityCounts_proc;
+
+CREATE PROCEDURE refresh_mvSingleComponentByServiceVulnerabilityCounts_proc()
+BEGIN
+    SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+    UPDATE mvSingleComponentByServiceVulnerabilityCounts
+    SET is_active = 0;
+
+    INSERT INTO mvSingleComponentByServiceVulnerabilityCounts (
+        service_id,
+        component_id,
+        critical_count,
+        high_count,
+        medium_count,
+        low_count,
+        none_count,
+        is_active
+    )
+    SELECT
+        CI.componentinstance_service_id,
+        CV.componentversion_component_id,
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Critical'
+            THEN CONCAT(CV.componentversion_component_id, ',', IV.issuevariant_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'High'
+            THEN CONCAT(CV.componentversion_component_id, ',', IV.issuevariant_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Medium'
+            THEN CONCAT(CV.componentversion_component_id, ',', IV.issuevariant_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Low'
+            THEN CONCAT(CV.componentversion_component_id, ',', IV.issuevariant_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'None'
+            THEN CONCAT(CV.componentversion_component_id, ',', IV.issuevariant_issue_id) END),
+        1
+    FROM IssueMatch IM
+    JOIN ComponentInstance CI ON CI.componentinstance_id = IM.issuematch_component_instance_id
+    JOIN ComponentVersion CV ON CV.componentversion_id = CI.componentinstance_component_version_id
+    JOIN IssueVariant IV ON IV.issuevariant_issue_id = IM.issuematch_issue_id
+    JOIN Issue I ON I.issue_id = IV.issuevariant_issue_id
+    WHERE IM.issuematch_status = 'new'
+      AND I.issue_type = 'Vulnerability'
+      AND IM.issuematch_deleted_at IS NULL
+      AND I.issue_deleted_at IS NULL
+      AND CI.componentinstance_deleted_at IS NULL
+      AND CV.componentversion_deleted_at IS NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM Remediation R
+          WHERE R.remediation_service_id = CI.componentinstance_service_id
+            AND R.remediation_issue_id = I.issue_id
+            AND R.remediation_deleted_at IS NULL
+            AND (R.remediation_expiration_date IS NULL OR R.remediation_expiration_date >= CURDATE())
+      )
+    GROUP BY CI.componentinstance_service_id, CV.componentversion_component_id
+    ON DUPLICATE KEY UPDATE
+        critical_count = VALUES(critical_count),
+        high_count     = VALUES(high_count),
+        medium_count   = VALUES(medium_count),
+        low_count      = VALUES(low_count),
+        none_count     = VALUES(none_count),
+        is_active      = 1;
+END;

--- a/internal/database/mariadb/migrations/20260618100000_fix_mv_single_component_use_issuematch_rating.up.sql
+++ b/internal/database/mariadb/migrations/20260618100000_fix_mv_single_component_use_issuematch_rating.up.sql
@@ -1,0 +1,72 @@
+-- SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Fix: The mvSingleComponentByServiceVulnerabilityCounts MV was using
+-- IV.issuevariant_rating to bucket severity counts, but the detail view
+-- (VulnerabilityBaseResolver with HasIssueMatches) filters on IM.issuematch_rating.
+-- These can diverge when a scanner re-rates a vulnerability without updating
+-- existing IssueMatches. Switch to IM.issuematch_rating so badge counts always
+-- match the detail view.
+--
+-- Additionally removes the IssueVariant JOIN from this procedure — it's no longer
+-- needed since we read severity directly from IssueMatch.
+
+DROP PROCEDURE IF EXISTS refresh_mvSingleComponentByServiceVulnerabilityCounts_proc;
+
+CREATE PROCEDURE refresh_mvSingleComponentByServiceVulnerabilityCounts_proc()
+BEGIN
+    SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+    UPDATE mvSingleComponentByServiceVulnerabilityCounts
+    SET is_active = 0;
+
+    INSERT INTO mvSingleComponentByServiceVulnerabilityCounts (
+        service_id,
+        component_id,
+        critical_count,
+        high_count,
+        medium_count,
+        low_count,
+        none_count,
+        is_active
+    )
+    SELECT
+        CI.componentinstance_service_id,
+        CV.componentversion_component_id,
+        COUNT(DISTINCT CASE WHEN IM.issuematch_rating = 'Critical'
+            THEN CONCAT(CV.componentversion_component_id, ',', IM.issuematch_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IM.issuematch_rating = 'High'
+            THEN CONCAT(CV.componentversion_component_id, ',', IM.issuematch_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IM.issuematch_rating = 'Medium'
+            THEN CONCAT(CV.componentversion_component_id, ',', IM.issuematch_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IM.issuematch_rating = 'Low'
+            THEN CONCAT(CV.componentversion_component_id, ',', IM.issuematch_issue_id) END),
+        COUNT(DISTINCT CASE WHEN IM.issuematch_rating = 'None'
+            THEN CONCAT(CV.componentversion_component_id, ',', IM.issuematch_issue_id) END),
+        1
+    FROM IssueMatch IM
+    JOIN ComponentInstance CI ON CI.componentinstance_id = IM.issuematch_component_instance_id
+    JOIN ComponentVersion CV ON CV.componentversion_id = CI.componentinstance_component_version_id
+    JOIN Issue I ON I.issue_id = IM.issuematch_issue_id
+    WHERE IM.issuematch_status = 'new'
+      AND I.issue_type = 'Vulnerability'
+      AND IM.issuematch_deleted_at IS NULL
+      AND I.issue_deleted_at IS NULL
+      AND CI.componentinstance_deleted_at IS NULL
+      AND CV.componentversion_deleted_at IS NULL
+      AND NOT EXISTS (
+          SELECT 1 FROM Remediation R
+          WHERE R.remediation_service_id = CI.componentinstance_service_id
+            AND R.remediation_issue_id = I.issue_id
+            AND R.remediation_deleted_at IS NULL
+            AND (R.remediation_expiration_date IS NULL OR R.remediation_expiration_date >= CURDATE())
+      )
+    GROUP BY CI.componentinstance_service_id, CV.componentversion_component_id
+    ON DUPLICATE KEY UPDATE
+        critical_count = VALUES(critical_count),
+        high_count     = VALUES(high_count),
+        medium_count   = VALUES(medium_count),
+        low_count      = VALUES(low_count),
+        none_count     = VALUES(none_count),
+        is_active      = 1;
+END;

--- a/internal/database/mariadb/test/fixture.go
+++ b/internal/database/mariadb/test/fixture.go
@@ -1238,6 +1238,7 @@ func (s *DatabaseSeeder) InsertFakeIssueMatch(im mariadb.IssueMatchRow) (int64, 
 			issuematch_user_id,
 			issuematch_remediation_date,
 			issuematch_target_remediation_date,
+			issuematch_deleted_at,
 			issuematch_created_by,
 			issuematch_updated_by
 		) VALUES (
@@ -1249,6 +1250,7 @@ func (s *DatabaseSeeder) InsertFakeIssueMatch(im mariadb.IssueMatchRow) (int64, 
 			:issuematch_user_id,
 			:issuematch_remediation_date,
 			:issuematch_target_remediation_date,
+			:issuematch_deleted_at,
 			:issuematch_created_by,
 			:issuematch_updated_by
 		)`

--- a/internal/e2e/image_query_test.go
+++ b/internal/e2e/image_query_test.go
@@ -7,7 +7,9 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"time"
 
+	"github.com/brianvoe/gofakeit/v7"
 	e2e_common "github.com/cloudoperators/heureka/internal/e2e/common"
 	"github.com/cloudoperators/heureka/internal/entity"
 	"github.com/samber/lo"
@@ -17,6 +19,7 @@ import (
 	"github.com/cloudoperators/heureka/internal/api/graphql/graph/model"
 	"github.com/cloudoperators/heureka/internal/database/mariadb"
 	"github.com/cloudoperators/heureka/internal/database/mariadb/test"
+	"github.com/cloudoperators/heureka/internal/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -200,6 +203,210 @@ var _ = Describe("Getting Images via API", Label("e2e", "Images"), func() {
 				Expect(hasVulns).To(BeTrue(), "at least one image should have Critical vulnerabilities")
 			},
 		)
+
+		It(
+			"vulnerability counts match detail view totals when filtered by service",
+			func() {
+				// Regression test: ensures that vulnerabilityCounts (from the MV) match
+				// the actual vulnerabilities returned by the detail view (fallthrough path)
+				// when both are scoped to the same service. Before the fix, clearing the
+				// service filter in VulnerabilityBaseResolver caused vulnerabilities from
+				// other services to leak into the detail view.
+				svcACCRN := imgTest.seedServiceScopedVulnData()
+
+				type vulnCountNode struct {
+					ID                  string                         `json:"id"`
+					Repository          *string                        `json:"repository"`
+					VulnerabilityCounts *model.SeverityCounts          `json:"vulnerabilityCounts"`
+					AllVulns            *model.VulnerabilityConnection `json:"allVulns"`
+					CriticalVulns       *model.VulnerabilityConnection `json:"criticalVulns"`
+					HighVulns           *model.VulnerabilityConnection `json:"highVulns"`
+				}
+
+				type vulnCountEdge struct {
+					Node *vulnCountNode `json:"node"`
+				}
+
+				type vulnCountConnection struct {
+					Edges []*vulnCountEdge `json:"edges"`
+				}
+
+				query := `query ($imgFilter: ImageFilter, $first: Int) {
+					Images(first: $first, filter: $imgFilter) {
+						edges {
+							node {
+								id
+								repository
+								vulnerabilityCounts {
+									critical
+									high
+									medium
+									low
+									none
+								}
+								allVulns: vulnerabilities {
+									totalCount
+								}
+								criticalVulns: vulnerabilities(filter: { severity: [Critical] }) {
+									totalCount
+								}
+								highVulns: vulnerabilities(filter: { severity: [High] }) {
+									totalCount
+								}
+							}
+						}
+					}
+				}`
+
+				respData, err := e2e_common.ExecuteGqlQuery[struct {
+					Images vulnCountConnection `json:"Images"`
+				}](
+					imgTest.port,
+					query,
+					map[string]any{
+						"imgFilter": map[string]any{
+							"service": []string{svcACCRN},
+						},
+						"first": 20,
+					},
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(respData.Images.Edges).ToNot(BeEmpty())
+
+				for _, edge := range respData.Images.Edges {
+					node := edge.Node
+					Expect(node.VulnerabilityCounts).ToNot(BeNil(),
+						"image %s must have vulnerability counts", node.ID)
+					Expect(node.CriticalVulns).ToNot(BeNil())
+					Expect(node.HighVulns).ToNot(BeNil())
+					Expect(node.AllVulns).ToNot(BeNil())
+
+					// Core regression assertion: badge count == filtered detail count
+					Expect(node.VulnerabilityCounts.Critical).To(
+						Equal(node.CriticalVulns.TotalCount),
+						"image %s: vulnerabilityCounts.critical (%d) must equal vulnerabilities(severity:Critical).totalCount (%d)",
+						node.ID, node.VulnerabilityCounts.Critical, node.CriticalVulns.TotalCount,
+					)
+
+					Expect(node.VulnerabilityCounts.High).To(
+						Equal(node.HighVulns.TotalCount),
+						"image %s: vulnerabilityCounts.high (%d) must equal vulnerabilities(severity:High).totalCount (%d)",
+						node.ID, node.VulnerabilityCounts.High, node.HighVulns.TotalCount,
+					)
+				}
+
+				// Sanity: find the seeded image (1 Critical, 1 High for service A)
+				foundCompX := false
+
+				for _, edge := range respData.Images.Edges {
+					node := edge.Node
+					if node.VulnerabilityCounts.Critical == 1 && node.VulnerabilityCounts.High == 1 {
+						foundCompX = true
+						// Verify detail counts match
+						Expect(node.CriticalVulns.TotalCount).To(Equal(1))
+						Expect(node.HighVulns.TotalCount).To(Equal(1))
+					}
+				}
+
+				Expect(foundCompX).To(BeTrue(),
+					"expected to find the seeded image with exactly 1 Critical and 1 High vulnerability "+
+						"scoped to service A; if counts differ, service B's IssueMatch is leaking through")
+			},
+		)
+
+		It(
+			"soft-deleted IssueMatches and rating mismatches do not cause count discrepancies",
+			func() {
+				// Regression test: ensures that:
+				// 1. Soft-deleted IssueMatches are excluded from the detail view
+				// 2. The MV counts use issuematch_rating (not issuevariant_rating),
+				//    so when they differ the counts still match the detail view.
+				svcCCRN := imgTest.seedRatingMismatchData()
+
+				type vulnNode struct {
+					ID                  string                         `json:"id"`
+					VulnerabilityCounts *model.SeverityCounts          `json:"vulnerabilityCounts"`
+					AllVulns            *model.VulnerabilityConnection `json:"allVulns"`
+					HighVulns           *model.VulnerabilityConnection `json:"highVulns"`
+					CriticalVulns       *model.VulnerabilityConnection `json:"criticalVulns"`
+				}
+
+				type vulnEdge struct {
+					Node *vulnNode `json:"node"`
+				}
+
+				type vulnConn struct {
+					Edges []*vulnEdge `json:"edges"`
+				}
+
+				query := `query ($imgFilter: ImageFilter, $first: Int) {
+					Images(first: $first, filter: $imgFilter) {
+						edges {
+							node {
+								id
+								vulnerabilityCounts {
+									critical
+									high
+								}
+								allVulns: vulnerabilities {
+									totalCount
+								}
+								criticalVulns: vulnerabilities(filter: { severity: [Critical] }) {
+									totalCount
+								}
+								highVulns: vulnerabilities(filter: { severity: [High] }) {
+									totalCount
+								}
+							}
+						}
+					}
+				}`
+
+				respData, err := e2e_common.ExecuteGqlQuery[struct {
+					Images vulnConn `json:"Images"`
+				}](
+					imgTest.port,
+					query,
+					map[string]any{
+						"imgFilter": map[string]any{
+							"service": []string{svcCCRN},
+						},
+						"first": 10,
+					},
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(respData.Images.Edges).ToNot(BeEmpty())
+
+				// Find the seeded image (should have exactly 1 Critical, 1 High)
+				// V1: IssueVariant=Critical, IssueMatch=Critical → counted as Critical
+				// V2: IssueVariant=High, IssueMatch=Critical (overridden) → counted as Critical
+				// V3: IssueVariant=High, IssueMatch=High → counted as High
+				// V4: IssueVariant=Medium, IssueMatch=Medium, soft-deleted → NOT counted
+				// Expected: critical=2, high=1
+				foundTarget := false
+
+				for _, edge := range respData.Images.Edges {
+					node := edge.Node
+					if node.VulnerabilityCounts.Critical == 2 && node.VulnerabilityCounts.High == 1 {
+						foundTarget = true
+
+						Expect(node.CriticalVulns.TotalCount).To(Equal(2),
+							"detail view critical count must match badge (both using issuematch_rating)")
+						Expect(node.HighVulns.TotalCount).To(Equal(1),
+							"detail view high count must match badge")
+						Expect(node.AllVulns.TotalCount).To(Equal(3),
+							"total should be 3 (V4 is soft-deleted and must not appear)")
+					}
+				}
+
+				Expect(foundTarget).To(BeTrue(),
+					"expected to find the seeded image with 2 Critical + 1 High; "+
+						"if not found, either the rating override (issuematch_rating) is not being "+
+						"used for counting, or soft-deleted IssueMatches are leaking through")
+			},
+		)
 	})
 })
 
@@ -369,6 +576,246 @@ func (it *imageTest) seedTieBreakerData() {
 
 	err = it.seeder.RefreshMvComponentService()
 	Expect(err).To(BeNil())
+}
+
+// seedServiceScopedVulnData seeds a controlled scenario to test that the detail view
+// correctly scopes vulnerabilities to the filtered service:
+// - Component X deployed in service A AND service B
+// - V1 (Critical) with IssueMatch only in service A
+// - V2 (High) with IssueMatch in both services
+// Returns service A's CCRN.
+func (it *imageTest) seedServiceScopedVulnData() string {
+	// Service A — the one to filter on
+	svcA := test.NewFakeBaseService()
+	svcAId, err := it.seeder.InsertFakeBaseService(svcA)
+	Expect(err).To(BeNil())
+
+	svcA.Id = sql.NullInt64{Int64: svcAId, Valid: true}
+
+	// Service B — must not bleed through
+	svcB := test.NewFakeBaseService()
+	svcBId, err := it.seeder.InsertFakeBaseService(svcB)
+	Expect(err).To(BeNil())
+
+	svcB.Id = sql.NullInt64{Int64: svcBId, Valid: true}
+
+	// Component X
+	compX := test.NewFakeComponent()
+	compXId, err := it.seeder.InsertFakeComponent(compX)
+	Expect(err).To(BeNil())
+
+	cvX := test.NewFakeComponentVersion()
+	cvX.ComponentId = sql.NullInt64{Int64: compXId, Valid: true}
+	cvXId, err := it.seeder.InsertFakeComponentVersion(cvX)
+	Expect(err).To(BeNil())
+
+	// V1 — Critical — IssueMatch only in service A
+	issueV1 := test.NewFakeIssue()
+	issueV1.Type = sql.NullString{String: entity.IssueTypeVulnerability.String(), Valid: true}
+	v1Id, err := it.seeder.InsertFakeIssue(issueV1)
+	Expect(err).To(BeNil())
+
+	_, err = it.seeder.InsertFakeIssueVariant(mariadb.IssueVariantRow{
+		SecondaryName:     sql.NullString{String: "CVE-REGRESSION-V1-CRITICAL", Valid: true},
+		Description:       sql.NullString{String: "service-A-only critical vuln", Valid: true},
+		IssueId:           sql.NullInt64{Int64: v1Id, Valid: true},
+		IssueRepositoryId: sql.NullInt64{Int64: 1, Valid: true},
+		Rating:            sql.NullString{String: entity.SeverityValuesCritical.String(), Valid: true},
+	})
+	Expect(err).To(BeNil())
+
+	cviV1 := test.NewFakeComponentVersionIssue()
+	cviV1.ComponentVersionId = sql.NullInt64{Int64: cvXId, Valid: true}
+	cviV1.IssueId = sql.NullInt64{Int64: v1Id, Valid: true}
+	_, err = it.seeder.InsertFakeComponentVersionIssue(cviV1)
+	Expect(err).To(BeNil())
+
+	// V2 — High — IssueMatch in both services
+	issueV2 := test.NewFakeIssue()
+	issueV2.Type = sql.NullString{String: entity.IssueTypeVulnerability.String(), Valid: true}
+	v2Id, err := it.seeder.InsertFakeIssue(issueV2)
+	Expect(err).To(BeNil())
+
+	_, err = it.seeder.InsertFakeIssueVariant(mariadb.IssueVariantRow{
+		SecondaryName:     sql.NullString{String: "CVE-REGRESSION-V2-HIGH", Valid: true},
+		Description:       sql.NullString{String: "both-services high vuln", Valid: true},
+		IssueId:           sql.NullInt64{Int64: v2Id, Valid: true},
+		IssueRepositoryId: sql.NullInt64{Int64: 1, Valid: true},
+		Rating:            sql.NullString{String: entity.SeverityValuesHigh.String(), Valid: true},
+	})
+	Expect(err).To(BeNil())
+
+	cviV2 := test.NewFakeComponentVersionIssue()
+	cviV2.ComponentVersionId = sql.NullInt64{Int64: cvXId, Valid: true}
+	cviV2.IssueId = sql.NullInt64{Int64: v2Id, Valid: true}
+	_, err = it.seeder.InsertFakeComponentVersionIssue(cviV2)
+	Expect(err).To(BeNil())
+
+	// ComponentInstance in service A
+	ciA := test.NewFakeComponentInstance()
+	ciA.ServiceId = sql.NullInt64{Int64: svcAId, Valid: true}
+	ciA.ComponentVersionId = sql.NullInt64{Int64: cvXId, Valid: true}
+	ciAId, err := it.seeder.InsertFakeComponentInstance(ciA)
+	Expect(err).To(BeNil())
+
+	// ComponentInstance in service B
+	ciB := test.NewFakeComponentInstance()
+	ciB.ServiceId = sql.NullInt64{Int64: svcBId, Valid: true}
+	ciB.ComponentVersionId = sql.NullInt64{Int64: cvXId, Valid: true}
+	ciBId, err := it.seeder.InsertFakeComponentInstance(ciB)
+	Expect(err).To(BeNil())
+
+	// IssueMatch: V1 only in service A
+	imV1A := test.NewFakeIssueMatch()
+	imV1A.Status = sql.NullString{String: entity.IssueMatchStatusValuesNew.String(), Valid: true}
+	imV1A.Rating = sql.NullString{String: entity.SeverityValuesCritical.String(), Valid: true}
+	imV1A.IssueId = sql.NullInt64{Int64: v1Id, Valid: true}
+	imV1A.ComponentInstanceId = sql.NullInt64{Int64: ciAId, Valid: true}
+	imV1A.UserId = sql.NullInt64{Int64: util.SystemUserId, Valid: true}
+	imV1A.RemediationDate = sql.NullTime{Time: time.Now().Add(30 * 24 * time.Hour), Valid: true}
+	imV1A.TargetRemediationDate = sql.NullTime{Time: time.Now().Add(60 * 24 * time.Hour), Valid: true}
+	_, err = it.seeder.InsertFakeIssueMatch(imV1A)
+	Expect(err).To(BeNil())
+
+	// IssueMatch: V2 in service A
+	imV2A := test.NewFakeIssueMatch()
+	imV2A.Status = sql.NullString{String: entity.IssueMatchStatusValuesNew.String(), Valid: true}
+	imV2A.Rating = sql.NullString{String: entity.SeverityValuesHigh.String(), Valid: true}
+	imV2A.IssueId = sql.NullInt64{Int64: v2Id, Valid: true}
+	imV2A.ComponentInstanceId = sql.NullInt64{Int64: ciAId, Valid: true}
+	imV2A.UserId = sql.NullInt64{Int64: util.SystemUserId, Valid: true}
+	imV2A.RemediationDate = sql.NullTime{Time: time.Now().Add(30 * 24 * time.Hour), Valid: true}
+	imV2A.TargetRemediationDate = sql.NullTime{Time: time.Now().Add(60 * 24 * time.Hour), Valid: true}
+	_, err = it.seeder.InsertFakeIssueMatch(imV2A)
+	Expect(err).To(BeNil())
+
+	// IssueMatch: V2 in service B — must NOT appear when filtering by service A
+	imV2B := test.NewFakeIssueMatch()
+	imV2B.Status = sql.NullString{String: entity.IssueMatchStatusValuesNew.String(), Valid: true}
+	imV2B.Rating = sql.NullString{String: entity.SeverityValuesHigh.String(), Valid: true}
+	imV2B.IssueId = sql.NullInt64{Int64: v2Id, Valid: true}
+	imV2B.ComponentInstanceId = sql.NullInt64{Int64: ciBId, Valid: true}
+	imV2B.UserId = sql.NullInt64{Int64: util.SystemUserId, Valid: true}
+	imV2B.RemediationDate = sql.NullTime{Time: time.Now().Add(30 * 24 * time.Hour), Valid: true}
+	imV2B.TargetRemediationDate = sql.NullTime{Time: time.Now().Add(60 * 24 * time.Hour), Valid: true}
+	_, err = it.seeder.InsertFakeIssueMatch(imV2B)
+	Expect(err).To(BeNil())
+
+	// Refresh all MVs
+	err = it.seeder.RefreshComponentVulnerabilityCounts()
+	Expect(err).To(BeNil())
+
+	err = it.seeder.RefreshMvComponentService()
+	Expect(err).To(BeNil())
+
+	err = it.seeder.RefreshMvVulnerabilityList()
+	Expect(err).To(BeNil())
+
+	return svcA.CCRN.String
+}
+
+// seedRatingMismatchData seeds a scenario to test:
+// 1. issuematch_rating is used for severity bucketing (not issuevariant_rating)
+// 2. Soft-deleted IssueMatches are excluded from both counts and detail view
+//
+// Setup:
+// - Component Y in service C
+// - V1: IssueVariant=Critical, IssueMatch=Critical (normal case)
+// - V2: IssueVariant=High, IssueMatch=Critical (overridden severity)
+// - V3: IssueVariant=High, IssueMatch=High (normal case)
+// - V4: IssueVariant=Medium, IssueMatch=Medium, soft-deleted
+//
+// Expected when using issuematch_rating: Critical=2, High=1, Medium=0
+// If issuevariant_rating were used: Critical=1, High=2, Medium=1
+func (it *imageTest) seedRatingMismatchData() string {
+	svc := test.NewFakeBaseService()
+	svcId, err := it.seeder.InsertFakeBaseService(svc)
+	Expect(err).To(BeNil())
+
+	comp := test.NewFakeComponent()
+	compId, err := it.seeder.InsertFakeComponent(comp)
+	Expect(err).To(BeNil())
+
+	cv := test.NewFakeComponentVersion()
+	cv.ComponentId = sql.NullInt64{Int64: compId, Valid: true}
+	cvId, err := it.seeder.InsertFakeComponentVersion(cv)
+	Expect(err).To(BeNil())
+
+	ci := test.NewFakeComponentInstance()
+	ci.ServiceId = sql.NullInt64{Int64: svcId, Valid: true}
+	ci.ComponentVersionId = sql.NullInt64{Int64: cvId, Valid: true}
+	ciId, err := it.seeder.InsertFakeComponentInstance(ci)
+	Expect(err).To(BeNil())
+
+	// V1: IssueVariant=Critical, IssueMatch=Critical
+	v1Id := it.seedIssueWithMatch(cvId, ciId, "Critical", "Critical", false)
+	_ = v1Id
+
+	// V2: IssueVariant=High, IssueMatch=Critical (severity overridden)
+	v2Id := it.seedIssueWithMatch(cvId, ciId, "High", "Critical", false)
+	_ = v2Id
+
+	// V3: IssueVariant=High, IssueMatch=High
+	v3Id := it.seedIssueWithMatch(cvId, ciId, "High", "High", false)
+	_ = v3Id
+
+	// V4: IssueVariant=Medium, IssueMatch=Medium, SOFT-DELETED
+	v4Id := it.seedIssueWithMatch(cvId, ciId, "Medium", "Medium", true)
+	_ = v4Id
+
+	// Refresh all MVs
+	err = it.seeder.RefreshComponentVulnerabilityCounts()
+	Expect(err).To(BeNil())
+
+	err = it.seeder.RefreshMvComponentService()
+	Expect(err).To(BeNil())
+
+	err = it.seeder.RefreshMvVulnerabilityList()
+	Expect(err).To(BeNil())
+
+	return svc.CCRN.String
+}
+
+// seedIssueWithMatch creates an Issue + IssueVariant + CVI + IssueMatch with configurable
+// variant rating, match rating, and soft-delete state.
+func (it *imageTest) seedIssueWithMatch(cvId, ciId int64, variantRating, matchRating string, deleted bool) int64 {
+	issue := test.NewFakeIssue()
+	issue.Type = sql.NullString{String: entity.IssueTypeVulnerability.String(), Valid: true}
+	issueId, err := it.seeder.InsertFakeIssue(issue)
+	Expect(err).To(BeNil())
+
+	_, err = it.seeder.InsertFakeIssueVariant(mariadb.IssueVariantRow{
+		SecondaryName:     sql.NullString{String: gofakeit.UUID(), Valid: true},
+		Description:       sql.NullString{String: "test variant", Valid: true},
+		IssueId:           sql.NullInt64{Int64: issueId, Valid: true},
+		IssueRepositoryId: sql.NullInt64{Int64: 1, Valid: true},
+		Rating:            sql.NullString{String: variantRating, Valid: true},
+	})
+	Expect(err).To(BeNil())
+
+	cvi := test.NewFakeComponentVersionIssue()
+	cvi.ComponentVersionId = sql.NullInt64{Int64: cvId, Valid: true}
+	cvi.IssueId = sql.NullInt64{Int64: issueId, Valid: true}
+	_, err = it.seeder.InsertFakeComponentVersionIssue(cvi)
+	Expect(err).To(BeNil())
+
+	im := test.NewFakeIssueMatch()
+	im.Status = sql.NullString{String: entity.IssueMatchStatusValuesNew.String(), Valid: true}
+	im.Rating = sql.NullString{String: matchRating, Valid: true}
+	im.IssueId = sql.NullInt64{Int64: issueId, Valid: true}
+	im.ComponentInstanceId = sql.NullInt64{Int64: ciId, Valid: true}
+	im.UserId = sql.NullInt64{Int64: util.SystemUserId, Valid: true}
+	im.RemediationDate = sql.NullTime{Time: time.Now().Add(30 * 24 * time.Hour), Valid: true}
+	im.TargetRemediationDate = sql.NullTime{Time: time.Now().Add(60 * 24 * time.Hour), Valid: true}
+
+	if deleted {
+		im.DeletedAt = sql.NullTime{Time: time.Now().Add(-24 * time.Hour), Valid: true}
+	}
+
+	_, err = it.seeder.InsertFakeIssueMatch(im)
+	Expect(err).To(BeNil())
+
+	return issueId
 }
 
 func (it *imageTest) testImageSortingWithTieBreaker() {


### PR DESCRIPTION
## Problem

When clicking an image card in a service-filtered view, the vulnerability detail list sometimes shows different counts than the badge on the card. In some cases it shows too many vulnerabilities (from other services), in other cases it shows too few (soft-deleted matches are excluded by the MV but not by the live query).

**Example:** Image `prom/prometheus` in `service-42` shows badge `critical: 1` but clicking through shows 4 critical vulnerabilities (from services 14, 20, 42, and 83).

## Root Cause Analysis

Two independent bugs conspire to create the mismatch:

### Bug 1: Cross-Service IssueMatch Leakage

PR #1222 fixed a 0-result bug by clearing the `ServiceCCRN` filter in `VulnerabilityBaseResolver` when resolving vulnerabilities for an Image parent. This was needed because `ServiceCCRN` triggers a **JOIN alias collision** between two paths that both emit `LEFT JOIN ComponentVersion CV`:

```
Path A (ServiceCCRN): IM_LJ → CI → CV (ON: CI.component_version_id = CV.id)
Path B (ComponentId):  CVI → CV (ON: CVI.component_version_id = CV.id)
```

The [JoinResolver deduplicates by table name](https://github.com/cloudoperators/heureka/blob/main/internal/database/mariadb/db_object.go#L755-L769) — whichever `CV` resolves first wins, the other's ON clause is silently dropped. PR #1222's workaround of clearing `ServiceCCRN` prevented the collision but removed service scoping entirely.

Additionally, even with service scoping via the `IM_RJ` path, IssueMatches from **other components** deployed in the same service would leak through because nothing correlated the IM→CI join path to the target component.

### Bug 2: Rating Column Mismatch + Soft-Delete Leak

The `mvSingleComponentByServiceVulnerabilityCounts` MV (which powers the badge counts) used `IV.issuevariant_rating` for severity bucketing:

```sql
COUNT(DISTINCT CASE WHEN IV.issuevariant_rating = 'Critical' THEN ... END)
```

But the detail view filters on `IM.issuematch_rating`:

```go
NewFilterProperty("IM.issuematch_rating = ?", func(filter *entity.IssueFilter) any { return filter.IssueMatchSeverity })
```

These columns can diverge when a scanner re-rates a vulnerability (updates IssueVariant) without updating existing IssueMatches. The badge would show the new rating, the detail view the old one.

Furthermore, soft-deleted IssueMatches (`issuematch_deleted_at IS NOT NULL`) were **never filtered** from the Issue query's IssueMatch join path. The MV's refresh procedure correctly filters them (`WHERE IM.issuematch_deleted_at IS NULL`), but the live query did not — causing ghost matches to appear in the detail view.

## Solution

### DB Layer Fix (`internal/database/mariadb/issue.go`)

All fixes are self-contained in the JoinDef/FilterProperty system:

1. **Soft-delete filter** — New `CustomFilterProperty` adds `IM.issuematch_deleted_at IS NULL` to the WHERE clause whenever the IssueMatch table is joined (when `HasIssueMatches`, `IssueMatchStatus`, `IssueMatchId`, or `IssueMatchSeverity` is set).

2. **Cross-component subquery** — New `FilterProperty` adds:
   ```sql
   IM.issuematch_component_instance_id IN (
     SELECT ci.componentinstance_id FROM ComponentInstance ci
     JOIN ComponentVersion cv ON ci.componentinstance_component_version_id = cv.componentversion_id
     WHERE cv.componentversion_component_id = ?
   )
   ```
   This activates when `HasIssueMatches && ComponentId` are both set, constraining IssueMatches to only those belonging to the target component. Self-contained (no dependency on CI being joined).

3. **Join routing** — When `HasIssueMatches` is true:
   - `CV with IM_LJ` is suppressed (prevents alias collision with `CV using CVI`)
   - `S with IM_LJ` is suppressed (service filtering goes through `S with IM_RJ` instead)
   - `S with IM_RJ` now activates for `HasIssueMatches && ServiceCCRN > 0`
   - `CV using CVI` is allowed when `ServiceCCRN` is set + `HasIssueMatches` (no collision since `CV with IM_LJ` is suppressed)

### API Layer (`internal/api/graphql/graph/baseResolver/vulnerability.go`)

Removed the PR #1222 workaround that cleared `ServiceCCRN` and `SupportGroupCCRN`. The service filter now passes through naturally — the DB layer handles dual scoping via the CVI path for ComponentId and the IM→CI→S path for service filtering.

### Migration (`20260618100000`)

Rewrites `refresh_mvSingleComponentByServiceVulnerabilityCounts_proc` to:
- Use `IM.issuematch_rating` instead of `IV.issuevariant_rating` for severity bucketing
- Remove the `IssueVariant` JOIN (no longer needed)
- Keep the existing `IM.issuematch_deleted_at IS NULL` filter (already correct in MV)

This ensures the MV counts use the same severity source as the detail view.

## Regression Tests

Two new E2E tests in `internal/e2e/image_query_test.go`:

### Test 1: `vulnerability counts match detail view totals when filtered by service`

Seeds:
- Component X deployed in service A AND service B
- V1 (Critical) with IssueMatch **only in service A**
- V2 (High) with IssueMatch in **both services**

Asserts when filtering by service A:
- `vulnerabilityCounts.critical == vulnerabilities(severity:Critical).totalCount` (both = 1)
- `vulnerabilityCounts.high == vulnerabilities(severity:High).totalCount` (both = 1)
- Total vulnerabilities = 2 (not 3 — service B's extra match must not leak)

### Test 2: `soft-deleted IssueMatches and rating mismatches do not cause count discrepancies`

Seeds:
- V1: IssueVariant=Critical, IssueMatch=Critical (normal)
- V2: IssueVariant=High, **IssueMatch=Critical** (overridden severity)
- V3: IssueVariant=High, IssueMatch=High (normal)
- V4: IssueVariant=Medium, IssueMatch=Medium, **soft-deleted**

Asserts:
- Badge shows Critical=2 (V1+V2 by `issuematch_rating`), High=1 (V3), total=3
- Detail view matches exactly (V4 excluded, V2 counted as Critical not High)

## Known Residual Discrepancy

A small number of images may still show badge > detail when an IssueMatch exists for a ComponentInstance of the component but there is no corresponding `ComponentVersionIssue` link. This is a **data integrity issue** (the MV counts by `IM→CI→CV` deployment path, while the detail view requires the `CVI→CV` issue-linkage path). Not introduced by this change.

## How to Verify

```graphql
query {
  Images(filter: {service: ["service-42"]}, first: 5) {
    edges { node {
      id repository
      vulnerabilityCounts { critical high medium }
      critical: vulnerabilities(filter: {severity: [Critical]}) { totalCount }
      high: vulnerabilities(filter: {severity: [High]}) { totalCount }
      medium: vulnerabilities(filter: {severity: [Medium]}) { totalCount }
    }}
  }
}
```

For each image: `vulnerabilityCounts.X == vulnerabilities(severity:X).totalCount`